### PR TITLE
Replace the generic "boost-devel" build dependency (bsc#1062805)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.yardoc
+doc/
+compile
 Makefile
 Makefile.am
 Makefile.am.common

--- a/package/yast2-squid.changes
+++ b/package/yast2-squid.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 13 10:35:05 UTC 2017 - lslezak@suse.cz
+
+- Replace the generic "boost-devel" build dependency with more
+  specific "libboost_regex-devel" (bsc#1062805)
+- 4.0.0
+
+-------------------------------------------------------------------
 Tue Jun  7 11:18:02 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-squid.spec
+++ b/package/yast2-squid.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-squid
 #
-# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,14 +17,20 @@
 
 
 Name:           yast2-squid
-Version:        3.1.5
+Version:        4.0.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
 
 Requires:       yast2 >= 2.21.22
+
+%if 0%{?suse_version} > 1325
+BuildRequires:  libboost_regex-devel
+%else
 BuildRequires:  boost-devel
+%endif
+
 BuildRequires:  gcc-c++
 BuildRequires:  libtool
 BuildRequires:  perl-XML-Writer


### PR DESCRIPTION
- Replace the generic `boost-devel` build dependency with more specific `libboost_regex-devel`
- See [bsc#1062805](https://bugzilla.suse.com/show_bug.cgi?id=1062805) and [bsc#1062583](https://bugzilla.suse.com/show_bug.cgi?id=1062583)
- (I have reused the `%suse_version` from [snapper](https://github.com/openSUSE/snapper/blob/3812bef4e27b83142c24cb41b34ea8adfc96aea5/snapper.spec.in#L24-L30), so it should be correct :wink: )
- 4.0.0