### PR TITLE
SuSEFIrewall2 replaced by firewalld (fate#323460)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM yastdevel/ruby
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  boost-devel \
+  libboost_regex-devel \
   gcc-c++ \
   libtool \
   yast2-core-devel

--- a/package/yast2-squid.changes
+++ b/package/yast2-squid.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 29 16:11:50 UTC 2018 - knut.anderssen@suse.com
+
+- Replace SuSEFirewall2 by firewalld (fate#323460)
+- 4.0.1
+
+-------------------------------------------------------------------
 Fri Oct 13 10:35:05 UTC 2017 - lslezak@suse.cz
 
 - Replace the generic "boost-devel" build dependency with more

--- a/package/yast2-squid.spec
+++ b/package/yast2-squid.spec
@@ -17,13 +17,14 @@
 
 
 Name:           yast2-squid
-Version:        4.0.0
+Version:        4.0.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
 
-Requires:       yast2 >= 2.21.22
+# SuSEFirewall2 replaced by firewalld (fate#323460)
+Requires:       yast2 >= 4.0.39
 
 %if 0%{?suse_version} > 1325
 BuildRequires:  libboost_regex-devel
@@ -35,7 +36,8 @@ BuildRequires:  gcc-c++
 BuildRequires:  libtool
 BuildRequires:  perl-XML-Writer
 BuildRequires:  update-desktop-files
-BuildRequires:  yast2
+# SuSEFirewall2 replaced by firewalld (fate#323460)
+BuildRequires:  yast2 >= 4.0.39
 BuildRequires:  yast2-core-devel
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  yast2-testsuite


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/99OkErr6/1093-8-firewall-firewalld-is-the-new-susefirewall-cwm)