### PR TITLE
Load the service widget lazily

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+# use the shared YaST defaults
+inherit_from:
+  /usr/share/YaST2/data/devtools/data/rubocop_yast_style.yml
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,74 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 28
 
+# Offense count: 23
+Style/Documentation:
+  Exclude:
+    - 'src/include/squid/popup_dialogs.rb'
+    - 'src/include/squid/handlers.rb'
+    - 'src/include/squid/store_del.rb'
+    - 'src/include/squid/inits.rb'
+    - 'src/include/squid/wizards.rb'
+    - 'src/include/squid/helps.rb'
+    - 'src/include/squid/helper_functions.rb'
+    - 'src/include/squid/SquidACL_local_functions.rb'
+    - 'src/include/squid/complex.rb'
+    - 'src/include/squid/dialogs.rb'
+    - 'src/modules/SquidACL.rb'
+    - 'src/modules/SquidACL.rb'
+    - 'src/modules/Squid.rb'
+    - 'src/modules/Squid.rb'
+    - 'src/modules/SquidErrorMessages.rb'
+    - 'src/modules/SquidErrorMessages.rb'
+    - 'src/clients/squid.rb'
+    - 'src/clients/squid_auto.rb'
+    - 'testsuite/tests/SquidACL.rb'
+    - 'testsuite/tests/Squid.rb'
+    - 'testsuite/tests/SquidErrorMessages.rb'
+    - 'testsuite/tests/Squid-Read.rb'
+    - 'testsuite/tests/complex_include_test.rb'
+
+# Offense count: 8
+# Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts.
+Style/FileName:
+  Exclude:
+    - 'src/include/squid/SquidACL_local_functions.rb'
+    - 'src/modules/Squid.rb'
+    - 'src/modules/SquidACL.rb'
+    - 'src/modules/SquidErrorMessages.rb'
+    - 'testsuite/tests/Squid-Read.rb'
+    - 'testsuite/tests/Squid.rb'
+    - 'testsuite/tests/SquidACL.rb'
+    - 'testsuite/tests/SquidErrorMessages.rb'
+
+# Offense count: 197
+# Configuration parameters: EnforcedStyle, SupportedStyles.
+# SupportedStyles: snake_case, camelCase
+Style/MethodName:
+  Exclude:
+    - 'src/clients/squid.rb'
+    - 'src/include/squid/SquidACL_local_functions.rb'
+    - 'src/include/squid/complex.rb'
+    - 'src/include/squid/dialogs.rb'
+    - 'src/include/squid/handlers.rb'
+    - 'src/include/squid/helper_functions.rb'
+    - 'src/include/squid/inits.rb'
+    - 'src/include/squid/popup_dialogs.rb'
+    - 'src/include/squid/store_del.rb'
+    - 'src/include/squid/wizards.rb'
+    - 'src/modules/Squid.rb'
+    - 'src/modules/SquidACL.rb'
+    - 'src/modules/SquidErrorMessages.rb'
+
+# Offense count: 19
+# Configuration parameters: EnforcedStyle, SupportedStyles.
+# SupportedStyles: snake_case, camelCase
+Style/VariableName:
+  Exclude:
+    - 'src/include/squid/helps.rb'
+    - 'src/include/squid/store_del.rb'
+    - 'src/modules/Squid.rb'
+    - 'testsuite/tests/Squid-Read.rb'
+    - 'testsuite/tests/Squid.rb'
+    - 'testsuite/tests/SquidACL.rb'
+    - 'testsuite/tests/SquidErrorMessages.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,45 @@
 inherit_from:
   /usr/share/YaST2/data/devtools/data/rubocop_yast_style.yml
 
+# Offense count: 32
+Metrics/AbcSize:
+  Max: 405
+
+# Offense count: 3
+Metrics/BlockNesting:
+  Max: 4
+
+# Offense count: 3
+# Configuration parameters: CountComments.
+Metrics/ClassLength:
+  Max: 1283
+
+# Offense count: 20
+Metrics/CyclomaticComplexity:
+  Max: 24
+
+# Offense count: 43
+# Configuration parameters: AllowHeredoc, AllowURI, URISchemes.
+# URISchemes: http, https
+Metrics/LineLength:
+  Max: 169
+
+# Offense count: 40
+# Configuration parameters: CountComments.
+Metrics/MethodLength:
+  Max: 314
+
+# Offense count: 8
+# Configuration parameters: CountComments.
+Metrics/ModuleLength:
+  Max: 577
+
+# Offense count: 1
+# Configuration parameters: CountKeywordArgs.
+Metrics/ParameterLists:
+  Max: 6
+
+# Offense count: 19
+Metrics/PerceivedComplexity:
+  Max: 28
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
 Yast::Tasks.configuration do |conf|
-  #lets ignore license check for now
+  # lets ignore license check for now
   conf.skip_license_check << /.*/
 end

--- a/package/yast2-squid.changes
+++ b/package/yast2-squid.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 17 08:18:00 UTC 2018 - dgonzalez@suse.com
+
+- Avoid crash when "squid" is not installed yet (bsc#1110076)
+- 4.1.1
+
+-------------------------------------------------------------------
 Tue Oct 16 15:52:18 CEST 2018 - schubi@suse.de
 
 - Added license file to spec.

--- a/package/yast2-squid.spec
+++ b/package/yast2-squid.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-squid
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/squid.rb
+++ b/src/clients/squid.rb
@@ -32,7 +32,7 @@ module Yast
     def main
       Yast.import "UI"
 
-      #**
+      # **
       # <h3>Configuration of squid</h3>
 
       textdomain "squid"
@@ -48,8 +48,6 @@ module Yast
       Yast.import "CommandLine"
       Yast.include self, "squid/wizards.rb"
       @finish = fun_ref(method(:init), "boolean ()")
-
-
 
       @cmdline_description = {
         "id"         => "squid",
@@ -80,7 +78,6 @@ module Yast
         "mappings"   => { "start" => [], "stop" => [] }
       }
 
-
       # is this proposal or not?
       @propose = false
       @args = WFM.Args
@@ -94,10 +91,10 @@ module Yast
       # main ui function
       @ret = nil
 
-      if @propose
-        @ret = SquidAutoSequence()
+      @ret = if @propose
+        SquidAutoSequence()
       else
-        @ret = CommandLine.Run(@cmdline_description)
+        CommandLine.Run(@cmdline_description)
       end
       Builtins.y2debug("ret=%1", @ret)
 
@@ -105,7 +102,7 @@ module Yast
       Builtins.y2milestone("Squid module finished")
       Builtins.y2milestone("----------------------------------------")
 
-      deep_copy(@ret) 
+      deep_copy(@ret)
 
       # EOF
     end
@@ -121,6 +118,7 @@ module Yast
         return false
       end
     end
+
     def stopHandler(options)
       options = deep_copy(options)
       CommandLine.PrintNoCR("Stopping service ...  ")

--- a/src/clients/squid.rb
+++ b/src/clients/squid.rb
@@ -107,8 +107,7 @@ module Yast
       # EOF
     end
 
-    def startHandler(options)
-      options = deep_copy(options)
+    def startHandler(_options)
       CommandLine.PrintNoCR("Starting service ...  ")
       if Squid.StartService
         CommandLine.Print("Success")
@@ -119,8 +118,7 @@ module Yast
       end
     end
 
-    def stopHandler(options)
-      options = deep_copy(options)
+    def stopHandler(_options)
       CommandLine.PrintNoCR("Stopping service ...  ")
       if Squid.StopService
         CommandLine.Print("Success")

--- a/src/clients/squid_auto.rb
+++ b/src/clients/squid_auto.rb
@@ -113,7 +113,7 @@ module Yast
       Builtins.y2milestone("Squid auto finished")
       Builtins.y2milestone("----------------------------------------")
 
-      deep_copy(@ret) 
+      deep_copy(@ret)
 
       # EOF
     end

--- a/src/include/squid/SquidACL_local_functions.rb
+++ b/src/include/squid/SquidACL_local_functions.rb
@@ -57,7 +57,6 @@ module Yast
     def isHHMMFormat(str)
       return false if !Builtins.regexpmatch(str, "^[0-9]{1,2}:[0-9]{1,2}$")
       hm = Builtins.splitstring(str, ":")
-      tmp = 0
 
       tmp = Builtins.tointeger(Ops.get(hm, 0, ""))
       return false if Ops.less_than(tmp, 0) || Ops.greater_than(tmp, 23)

--- a/src/include/squid/SquidACL_local_functions.rb
+++ b/src/include/squid/SquidACL_local_functions.rb
@@ -53,6 +53,7 @@ module Yast
     def isMask(str)
       Builtins.regexpmatch(str, "^[0-9]+$") || isIPAddr(str)
     end
+
     def isHHMMFormat(str)
       return false if !Builtins.regexpmatch(str, "^[0-9]{1,2}:[0-9]{1,2}$")
       hm = Builtins.splitstring(str, ":")
@@ -65,6 +66,7 @@ module Yast
 
       true
     end
+
     def isCorrectFromTo(from, to)
       fr = Builtins.tointeger(
         Builtins.regexpsub(
@@ -84,20 +86,20 @@ module Yast
       Ops.less_than(fr, t)
     end
 
-
-
     def widgetInitIPAddr(id)
       id = deep_copy(id)
       UI.ChangeWidget(Id(id), :ValidChars, "1234567890.")
 
       nil
     end
+
     def widgetInitMask(id)
       id = deep_copy(id)
       UI.ChangeWidget(Id(id), :ValidChars, "1234567890.")
 
       nil
     end
+
     def widgetInitDomainName(id)
       id = deep_copy(id)
       UI.ChangeWidget(
@@ -108,6 +110,7 @@ module Yast
 
       nil
     end
+
     def widgetInitHHMM(id)
       id = deep_copy(id)
       UI.ChangeWidget(Id(id), :ValidChars, "1234567890:")
@@ -116,13 +119,12 @@ module Yast
       nil
     end
 
-
-    #*****************  SRC  ************************
+    # *****************  SRC  ************************
     def srcWidgetInit(id_item)
       UI.ChangeWidget(Id("acl_addr"), :ValidChars, "1234567890.-")
       widgetInitMask("acl_mask")
 
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
         data = Builtins.splitstring(
           Ops.get(Ops.get_list(acl, "options", []), 0, ""),
@@ -144,7 +146,7 @@ module Yast
 
       if Builtins.size(addr) == 0 ||
           !isIPAddr(addr) && !isIPAddr(Ops.get(tmp, 0, "")) &&
-            !isIPAddr(Ops.get(tmp, 1, "")) ||
+              !isIPAddr(Ops.get(tmp, 1, "")) ||
           Ops.greater_than(Builtins.size(mask), 0) && !isMask(mask)
         ok = false
         Report.Error(_("Invalid values."))
@@ -164,15 +166,14 @@ module Yast
       end
       deep_copy(data)
     end
-    #*****************  SRC END  ********************
+    # *****************  SRC END  ********************
 
-
-    #*****************  DST  ************************
+    # *****************  DST  ************************
     def dstWidgetInit(id_item)
       widgetInitIPAddr("acl_addr")
       widgetInitMask("acl_mask")
 
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
         data = Builtins.splitstring(
           Ops.get(Ops.get_list(acl, "options", []), 0, ""),
@@ -211,19 +212,17 @@ module Yast
       end
       deep_copy(data)
     end
-    #*****************  DST END  ********************
-
+    # *****************  DST END  ********************
 
     # *****************  MYIP  ************************
     #  * Uses same functions as DST
     # /******************  MYIP END  *******************
 
-
-    #***************  SRCDOMAIN  ********************
+    # ***************  SRCDOMAIN  ********************
     def srcdomainWidgetInit(id_item)
       widgetInitDomainName("acl_domain")
 
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
         UI.ChangeWidget(
           Id("acl_domain"),
@@ -234,28 +233,29 @@ module Yast
 
       nil
     end
+
     def srcdomainVerif
       ok = true
 
       if Builtins.size(
-          Convert.to_string(UI.QueryWidget(Id("acl_domain"), :Value))
-        ) == 0
+        Convert.to_string(UI.QueryWidget(Id("acl_domain"), :Value))
+      ) == 0
         ok = false
         Report.Error(_("Domain Name must not be empty."))
       end
       ok
     end
+
     def srcdomainOptions
       [Convert.to_string(UI.QueryWidget(Id("acl_domain"), :Value))]
     end
-    #***************  SRCDOMAIN END  ****************
+    # ***************  SRCDOMAIN END  ****************
 
     # ***************  DSTDOMAIN  *********************
     #  * Uses same functions as SRCDOMAIN.
     # /****************  DSTDOMAIN END  ****************
 
-
-    #***************  REGEXP  ***********************
+    # ***************  REGEXP  ***********************
     # Returns universal widget for setting a regular expression.
     def regexpWidget(frame_title)
       Frame(
@@ -275,7 +275,7 @@ module Yast
 
     # Universal widget_init for regular expression.
     def regexpWidgetInit(id_item)
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
 
         if Ops.get(Ops.get_list(acl, "options", []), 0, "") == "-i"
@@ -295,6 +295,7 @@ module Yast
 
       nil
     end
+
     # Universal verification function for regular expression.
     def regexpVerif
       ok = true
@@ -306,12 +307,13 @@ module Yast
       end
       ok
     end
+
     # Universal options function for regular expression.
     def regexpOptions
       ret = []
       if Convert.to_boolean(
-          UI.QueryWidget(Id("acl_regexp_case_insensitive"), :Value)
-        )
+        UI.QueryWidget(Id("acl_regexp_case_insensitive"), :Value)
+      )
         Ops.set(ret, 0, "-i")
       end
       ret = Builtins.add(
@@ -332,16 +334,14 @@ module Yast
         "help"         => help
       }
     end
-    #***************  REGEXP END  *******************
+    # ***************  REGEXP END  *******************
 
-
-
-    #***************  TIME  *************************
+    # ***************  TIME  *************************
     def timeWidgetInit(id_item)
       widgetInitHHMM("acl_from")
       widgetInitHHMM("acl_to")
 
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
         days = splitToChars(Ops.get(Ops.get_list(acl, "options", []), 0, ""))
         times = Builtins.splitstring(
@@ -356,6 +356,7 @@ module Yast
 
       nil
     end
+
     def timeVerif
       ok = true
       from = Convert.to_string(UI.QueryWidget(Id("acl_from"), :Value))
@@ -372,16 +373,17 @@ module Yast
         Report.Error(_("Time is not set in correct format."))
       elsif !isCorrectFromTo(from, to)
         ok = false
-        Report.Error(_("From must be less than To.")) #TODO: better error message
+        Report.Error(_("From must be less than To.")) # TODO: better error message
       end
       ok
     end
+
     def timeOptions
       days = Builtins.mergestring(
         Convert.convert(
           UI.QueryWidget(Id("acl_days"), :SelectedItems),
-          :from => "any",
-          :to   => "list <string>"
+          from: "any",
+          to:   "list <string>"
         ),
         ""
       )
@@ -394,14 +396,13 @@ module Yast
       )
       [days, times]
     end
-    #***************  TIME END  *********************
+    # ***************  TIME END  *********************
 
-
-    #***************  PORT  *************************
+    # ***************  PORT  *************************
     def portWidgetInit(id_item)
       UI.ChangeWidget(Id("acl_port"), :ValidChars, "1234567890-")
 
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
 
         UI.ChangeWidget(
@@ -413,6 +414,7 @@ module Yast
 
       nil
     end
+
     def portVerif
       ok = true
       port = Convert.to_string(UI.QueryWidget(Id("acl_port"), :Value))
@@ -432,17 +434,17 @@ module Yast
       Report.Error(_("Invalid value.")) if !ok
       ok
     end
+
     def portOptions
       [Convert.to_string(UI.QueryWidget(Id("acl_port"), :Value))]
     end
-    #***************  PORT END  *********************
+    # ***************  PORT END  *********************
 
-
-    #*************  MYPORT  *************************
+    # *************  MYPORT  *************************
     def myportWidgetInit(id_item)
       UI.ChangeWidget(Id("acl_port"), :ValidChars, "1234567890")
 
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
 
         UI.ChangeWidget(
@@ -454,6 +456,7 @@ module Yast
 
       nil
     end
+
     def myportVerif
       ok = true
       port = Convert.to_string(UI.QueryWidget(Id("acl_port"), :Value))
@@ -464,10 +467,9 @@ module Yast
       end
       ok
     end
-    #*************  MYPORT END  *********************
+    # *************  MYPORT END  *********************
 
-
-    #**************  PROTO  *************************
+    # **************  PROTO  *************************
     def protoWidgetInit(id_item)
       UI.ChangeWidget(
         Id("acl_proto"),
@@ -475,7 +477,7 @@ module Yast
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_"
       )
 
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
 
         UI.ChangeWidget(
@@ -487,6 +489,7 @@ module Yast
 
       nil
     end
+
     def protoVerif
       ok = true
       protocol = Convert.to_string(UI.QueryWidget(Id("acl_proto"), :Value))
@@ -496,15 +499,15 @@ module Yast
       end
       ok
     end
+
     def protoOptions
       [Convert.to_string(UI.QueryWidget(Id("acl_proto"), :Value))]
     end
-    #**************  PROTO END  *********************
+    # **************  PROTO END  *********************
 
-
-    #**************  METHOD  ************************
+    # **************  METHOD  ************************
     def methodWidgetInit(id_item)
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
 
         UI.ChangeWidget(
@@ -516,18 +519,19 @@ module Yast
 
       nil
     end
+
     def methodVerif
       true
     end
+
     def methodOptions
       [Convert.to_string(UI.QueryWidget(Id("acl_method"), :Value))]
     end
-    #**************  METHOD END  ********************
+    # **************  METHOD END  ********************
 
-
-    #**************  MAXCONN  ***********************
+    # **************  MAXCONN  ***********************
     def maxconnWidgetInit(id_item)
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
 
         UI.ChangeWidget(
@@ -539,18 +543,19 @@ module Yast
 
       nil
     end
+
     def maxconnVerif
       true
     end
+
     def maxconnOptions
       [Builtins.tostring(UI.QueryWidget(Id("acl_connections"), :Value))]
     end
-    #**************  MAXCONN END  *******************
+    # **************  MAXCONN END  *******************
 
-
-    #**************  HEADER  ************************
+    # **************  HEADER  ************************
     def headerWidgetInit(id_item)
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
         UI.ChangeWidget(
           Id("acl_header_name"),
@@ -575,6 +580,7 @@ module Yast
 
       nil
     end
+
     def headerVerif
       ok = true
       header_name = Convert.to_string(
@@ -588,6 +594,7 @@ module Yast
       end
       ok
     end
+
     def headerOptions
       header_name = Convert.to_string(
         UI.QueryWidget(Id("acl_header_name"), :Value)
@@ -603,14 +610,13 @@ module Yast
 
       deep_copy(ret)
     end
-    #**************  HEADER END  ********************
+    # **************  HEADER END  ********************
 
-
-    #**************  ARP  ***************************
+    # **************  ARP  ***************************
     def arpWidgetInit(id_item)
       UI.ChangeWidget(Id("acl_mac"), :ValidChars, "1234567890ABCDEFabcdef:")
 
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
         UI.ChangeWidget(
           Id("acl_mac"),
@@ -621,6 +627,7 @@ module Yast
 
       nil
     end
+
     def arpVerif
       ok = true
       mac = Convert.to_string(UI.QueryWidget(Id("acl_mac"), :Value))
@@ -635,6 +642,7 @@ module Yast
       end
       ok
     end
+
     def arpOptions
       [Convert.to_string(UI.QueryWidget(Id("acl_mac"), :Value))]
     end

--- a/src/include/squid/complex.rb
+++ b/src/include/squid/complex.rb
@@ -69,7 +69,7 @@ module Yast
     #
     # @return [Symbol] :abort when settings could not be read; :next otherwise
     def ReadDialog
-      Wizard.RestoreHelp(Ops.get_string(@HELPS, "read", ""))
+      Wizard.RestoreHelp(@HELPS["read"])
       Squid.AbortFunction = fun_ref(method(:PollAbort), "boolean ()")
 
       return :abort unless Confirm.MustBeRoot
@@ -85,7 +85,7 @@ module Yast
     #
     # @return [Symbol] :abort if aborted, :next otherwise
     def WriteDialog
-      help = @HELPS.fetch("write") { "" }
+      help = @HELPS["write"]
 
       Wizard.CreateDialog
       Wizard.RestoreHelp(help)
@@ -93,8 +93,7 @@ module Yast
       result = Squid.Write
       Wizard.CloseDialog
 
-      return :next if result
-      :abort
+      result ? :next : :abort
     end
 
     def SaveAndRestart
@@ -118,7 +117,7 @@ module Yast
       )
     end
 
-    private
+  private
 
     # Add the service wiget if is not already included
     #

--- a/src/include/squid/complex.rb
+++ b/src/include/squid/complex.rb
@@ -102,18 +102,16 @@ module Yast
 
     def MainDialog
       DialogTree.ShowAndRun(
-        {
-          "ids_order"      => @ids_order,
-          "initial_screen" => @initial_screen,
-          "widget_descr"   => @widget_descr,
-          "screens"        => @screens,
-          "functions"      => {
-            :abort => fun_ref(method(:ReallyAbort), "boolean ()")
-          },
-          "back_button"    => "",
-          "next_button"    => Label.OKButton,
-          "abort_button"   => Label.CancelButton
-        }
+        "ids_order"      => @ids_order,
+        "initial_screen" => @initial_screen,
+        "widget_descr"   => @widget_descr,
+        "screens"        => @screens,
+        "functions"      => {
+          abort: fun_ref(method(:ReallyAbort), "boolean ()")
+        },
+        "back_button"    => "",
+        "next_button"    => Label.OKButton,
+        "abort_button"   => Label.CancelButton
       )
     end
 
@@ -141,11 +139,9 @@ module Yast
     def load_widgets
       @widget_descr = {
         "firewall"               => CWMFirewallInterfaces.CreateOpenFirewallWidget(
-          {
-            "services"               => [Squid.GetFirewallServiceName],
-            "display_details"        => true,
-            "open_firewall_checkbox" => _("Open Ports in Firewall")
-          }
+          "services"               => [Squid.GetFirewallServiceName],
+          "display_details"        => true,
+          "open_firewall_checkbox" => _("Open Ports in Firewall")
         ),
         "http_ports_table"       => {
           "widget"        => :custom,

--- a/src/include/squid/dialogs.rb
+++ b/src/include/squid/dialogs.rb
@@ -60,7 +60,7 @@ module Yast
             Id("refresh_patterns"),
             Opt(:keepSorting, :notify),
             Header(
-              _("Regular Expression"), #, _("Options")
+              _("Regular Expression"), # , _("Options")
               # table header, stands for minimum
               _("Min"),
               # table header
@@ -191,7 +191,7 @@ module Yast
           )
         ),
         HSpacing(3)
-      ) 
+      )
       #     `HBox(
       #         `HSpacing(3),
       #         `Frame(_("Cache Setting"),
@@ -265,8 +265,6 @@ module Yast
         HSpacing(3)
       )
     end
-
-
 
     def ACLGroupsTableWidget
       VBox(
@@ -361,7 +359,6 @@ module Yast
         )
       )
     end
-
 
     def MiscellaneousFrameWidget
       HVCenter(

--- a/src/include/squid/handlers.rb
+++ b/src/include/squid/handlers.rb
@@ -119,8 +119,6 @@ module Yast
     def HandleCache2Dialog(_widget_id, event_map)
       event_map = deep_copy(event_map)
       ui = Ops.get(event_map, "ID")
-      tmp = nil
-      tmp2 = nil
 
       # cache_min_object_size <= cache_max_object_size
       if ui == "cache_min_object_size" || ui == "cache_min_object_size_units"

--- a/src/include/squid/handlers.rb
+++ b/src/include/squid/handlers.rb
@@ -69,8 +69,7 @@ module Yast
       nil
     end
 
-
-    def HandleRefreshPatternsTable(widget_id, event_map)
+    def HandleRefreshPatternsTable(_widget_id, event_map)
       event_map = deep_copy(event_map)
       ui = Ops.get(event_map, "ID")
       id_item = nil
@@ -99,7 +98,7 @@ module Yast
             UI.QueryWidget(Id("refresh_patterns"), :CurrentItem)
           )
         )
-        if id_item != nil
+        if !id_item.nil?
           InitRefreshPatternsTable("")
           UI.ChangeWidget(Id("refresh_patterns"), :CurrentItem, id_item)
         end
@@ -109,7 +108,7 @@ module Yast
             UI.QueryWidget(Id("refresh_patterns"), :CurrentItem)
           )
         )
-        if id_item != nil
+        if !id_item.nil?
           InitRefreshPatternsTable("")
           UI.ChangeWidget(Id("refresh_patterns"), :CurrentItem, id_item)
         end
@@ -117,14 +116,13 @@ module Yast
       nil
     end
 
-
-    def HandleCache2Dialog(widget_id, event_map)
+    def HandleCache2Dialog(_widget_id, event_map)
       event_map = deep_copy(event_map)
       ui = Ops.get(event_map, "ID")
       tmp = nil
       tmp2 = nil
 
-      #cache_min_object_size <= cache_max_object_size
+      # cache_min_object_size <= cache_max_object_size
       if ui == "cache_min_object_size" || ui == "cache_min_object_size_units"
         tmp = Ops.multiply(
           Convert.to_integer(
@@ -190,30 +188,30 @@ module Yast
             :Value,
             UI.QueryWidget(Id("cache_max_object_size_units"), :Value)
           )
-        end 
+        end
 
-        #cache_swap_low <= cache_swap_high
+        # cache_swap_low <= cache_swap_high
       elsif ui == "cache_swap_low"
         tmp = UI.QueryWidget(Id("cache_swap_low"), :Value)
         if Ops.greater_than(
-            Convert.to_integer(tmp),
-            Convert.to_integer(UI.QueryWidget(Id("cache_swap_high"), :Value))
-          )
+          Convert.to_integer(tmp),
+          Convert.to_integer(UI.QueryWidget(Id("cache_swap_high"), :Value))
+        )
           UI.ChangeWidget(Id("cache_swap_high"), :Value, tmp)
         end
       elsif ui == "cache_swap_high"
         tmp = UI.QueryWidget(Id("cache_swap_high"), :Value)
         if Ops.greater_than(
-            Convert.to_integer(UI.QueryWidget(Id("cache_swap_low"), :Value)),
-            Convert.to_integer(tmp)
-          )
+          Convert.to_integer(UI.QueryWidget(Id("cache_swap_low"), :Value)),
+          Convert.to_integer(tmp)
+        )
           UI.ChangeWidget(Id("cache_swap_low"), :Value, tmp)
         end
       end
       nil
     end
 
-    def HandleCacheDirectoryDialog(widget_id, event_map)
+    def HandleCacheDirectoryDialog(_widget_id, event_map)
       event_map = deep_copy(event_map)
       ui = Ops.get(event_map, "ID")
       cache_dir = ""
@@ -223,13 +221,13 @@ module Yast
           Convert.to_string(UI.QueryWidget(Id("cache_dir"), :Value)),
           _("Cache Directory")
         )
-        UI.ChangeWidget(Id("cache_dir"), :Value, cache_dir) if cache_dir != nil
+        UI.ChangeWidget(Id("cache_dir"), :Value, cache_dir) if !cache_dir.nil?
       end
 
       nil
     end
 
-    def HandleAccessControlDialog(widget_id, event_map)
+    def HandleAccessControlDialog(_widget_id, event_map)
       event_map = deep_copy(event_map)
       ui = Ops.get(event_map, "ID")
       id_item = nil
@@ -268,7 +266,7 @@ module Yast
         id_item = MoveUpHttpAccess(
           Convert.to_integer(UI.QueryWidget(Id("http_access"), :CurrentItem))
         )
-        if id_item != nil
+        if !id_item.nil?
           InitHttpAccessTable("")
           UI.ChangeWidget(Id("http_access"), :CurrentItem, id_item)
         end
@@ -276,7 +274,7 @@ module Yast
         id_item = MoveDownHttpAccess(
           Convert.to_integer(UI.QueryWidget(Id("http_access"), :CurrentItem))
         )
-        if id_item != nil
+        if !id_item.nil?
           InitHttpAccessTable("")
           UI.ChangeWidget(Id("http_access"), :CurrentItem, id_item)
         end
@@ -284,21 +282,20 @@ module Yast
       nil
     end
 
-
-    def HandleLoggingFrame(widget_id, event_map)
+    def HandleLoggingFrame(_widget_id, event_map)
       event_map = deep_copy(event_map)
       ui = Ops.get(event_map, "ID")
       tmp = nil
 
       if ui == :access_log_browse
         tmp = UI.AskForExistingFile("/var/log", "*", _("Access Log"))
-        UI.ChangeWidget(Id("access_log"), :Value, tmp) if tmp != nil
+        UI.ChangeWidget(Id("access_log"), :Value, tmp) if !tmp.nil?
       elsif ui == :cache_log_browse
         tmp = UI.AskForExistingFile("/var/log", "*", _("Cache Log"))
-        UI.ChangeWidget(Id("cache_log"), :Value, tmp) if tmp != nil
+        UI.ChangeWidget(Id("cache_log"), :Value, tmp) if !tmp.nil?
       elsif ui == :cache_store_log_browse
         tmp = UI.AskForExistingFile("/var/log", "*", _("Cache Store Log"))
-        UI.ChangeWidget(Id("cache_store_log"), :Value, tmp) if tmp != nil
+        UI.ChangeWidget(Id("cache_store_log"), :Value, tmp) if !tmp.nil?
       end
       nil
     end

--- a/src/include/squid/helper_functions.rb
+++ b/src/include/squid/helper_functions.rb
@@ -27,7 +27,7 @@
 # $Id: dialogs.ycp 27914 2006-02-13 14:32:08Z locilka $
 module Yast
   module SquidHelperFunctionsInclude
-    def initialize_squid_helper_functions(include_target)
+    def initialize_squid_helper_functions(_include_target)
       textdomain "squid"
 
       Yast.import "FileUtils"
@@ -46,7 +46,6 @@ module Yast
       nil
     end
 
-
     # Returns a widget with setting of units
     def timeUnitWidget(id)
       ComboBox(
@@ -60,7 +59,6 @@ module Yast
         ]
       )
     end
-
 
     def isCorrectPathnameOfLogFile(str)
       ok = Builtins.regexpmatch(str, "^/([^/]+/)*[^/]+$")
@@ -95,8 +93,8 @@ module Yast
     end
 
     def isHostName(str)
-      #max 22 chars length
-      #see http://www.no-ip.com/support/faq/EN/dynamic_ddns/what_is_a_valid_hostname.html
+      # max 22 chars length
+      # see http://www.no-ip.com/support/faq/EN/dynamic_ddns/what_is_a_valid_hostname.html
       Builtins.regexpmatch(str, "^[a-zA-Z0-9][a-zA-Z0-9-]{0,21}$")
     end
 

--- a/src/include/squid/helps.rb
+++ b/src/include/squid/helps.rb
@@ -25,7 +25,7 @@
 # $Id: helps.ycp 27914 2006-02-13 14:32:08Z locilka $
 module Yast
   module SquidHelpsInclude
-    def initialize_squid_helps(include_target)
+    def initialize_squid_helps(_include_target)
       textdomain "squid"
 
       # All helps are here
@@ -44,9 +44,9 @@ module Yast
         ) +
           # Write dialog help 2/2
           _(
-            "<p><b><big>Aborting Saving:</big></b><br>\n" +
-              "Abort the save procedure by pressing <b>Abort</b>.\n" +
-              "An additional dialog informs whether it is safe to do so.\n" +
+            "<p><b><big>Aborting Saving:</big></b><br>\n" \
+              "Abort the save procedure by pressing <b>Abort</b>.\n" \
+              "An additional dialog informs whether it is safe to do so.\n" \
               "</p>\n"
           ),
         # Summary dialog help
@@ -55,8 +55,8 @@ module Yast
         ),
         # Ovreview dialog help
         "overview"        => _(
-          "<p><b><big>Squid Configuration Overview</big></b><br>\n" +
-            "Obtain an overview of installed squids and\n" +
+          "<p><b><big>Squid Configuration Overview</big></b><br>\n" \
+            "Obtain an overview of installed squids and\n" \
             "edit their configurations if necessary.<br></p>\n"
         ),
         # Http Ports Dialog
@@ -77,8 +77,8 @@ module Yast
             "<p><b>Min</b> determines how long (in minutes) an object should be\nconsidered fresh if no explicit expiry time is given.\n"
           ) +
           _(
-            "<p><b>Percent</b> is the percentage of the object's age (time since last\n" +
-              "modification). An object without explicit expiry time will be\n" +
+            "<p><b>Percent</b> is the percentage of the object's age (time since last\n" \
+              "modification). An object without explicit expiry time will be\n" \
               "considered fresh.</p>\n"
           ) +
           _(
@@ -95,37 +95,37 @@ module Yast
             "<p><b>Min Object Size</b> specifies the minimum size for objects. Smaller \nobjects will not be saved to the disk.</p>\n"
           ) +
           _(
-            "<p>Replacement begins when the swap (disk) usage is above the\n" +
-              "<b>Swap Low-Water Mark</b> and attempts to maintain utilization near the\n" +
-              "<b>Swap Low-Water Mark</b>. As swap utilization gets close to\n" +
-              "<b>Swap High-Water Mark</b>, object eviction becomes more aggressive.\n" +
-              "If utilization is close to the <b>Swap Low-Water Mark</b>, less replacement\n" +
+            "<p>Replacement begins when the swap (disk) usage is above the\n" \
+              "<b>Swap Low-Water Mark</b> and attempts to maintain utilization near the\n" \
+              "<b>Swap Low-Water Mark</b>. As swap utilization gets close to\n" \
+              "<b>Swap High-Water Mark</b>, object eviction becomes more aggressive.\n" \
+              "If utilization is close to the <b>Swap Low-Water Mark</b>, less replacement\n" \
               "is done each time.\n"
           ) +
           _(
-            "<p><b>Cache Replacement Policy</b> determines which objects are to be replaced\n" +
-              "when disk space is needed.\n" +
-              "<b>Memory Replacement Policy</b> specifies the policy for object replacement in\n" +
-              "memory when space for new objects is not available.\n" +
-              "Policies could be:\n" +
-              "<table>\n" +
-              "    <tr>\n" +
-              "      <td>lru</td>\n" +
-              "      <td>least recently used</td>\n" +
-              "    </tr>\n" +
-              "    <tr>\n" +
-              "      <td>heap GDSF</td>\n" +
-              "      <td>Greedy-Dual Size Frequency</td>\n" +
-              "    </tr>\n" +
-              "    <tr>\n" +
-              "      <td>heap LFUDA</td>\n" +
-              "      <td>Least Frequently Used with Dynamic Aging</td>\n" +
-              "    <tr>\n" +
-              "    <tr>\n" +
-              "      <td>heap LRU</td>\n" +
-              "      <td>lru policy implemented using a heap</td>\n" +
-              "    </tr>\n" +
-              "</table>\n" +
+            "<p><b>Cache Replacement Policy</b> determines which objects are to be replaced\n" \
+              "when disk space is needed.\n" \
+              "<b>Memory Replacement Policy</b> specifies the policy for object replacement in\n" \
+              "memory when space for new objects is not available.\n" \
+              "Policies could be:\n" \
+              "<table>\n" \
+              "    <tr>\n" \
+              "      <td>lru</td>\n" \
+              "      <td>least recently used</td>\n" \
+              "    </tr>\n" \
+              "    <tr>\n" \
+              "      <td>heap GDSF</td>\n" \
+              "      <td>Greedy-Dual Size Frequency</td>\n" \
+              "    </tr>\n" \
+              "    <tr>\n" \
+              "      <td>heap LFUDA</td>\n" \
+              "      <td>Least Frequently Used with Dynamic Aging</td>\n" \
+              "    <tr>\n" \
+              "    <tr>\n" \
+              "      <td>heap LRU</td>\n" \
+              "      <td>lru policy implemented using a heap</td>\n" \
+              "    </tr>\n" \
+              "</table>\n" \
               "</p>"
           ),
         # Cache Directory
@@ -149,8 +149,8 @@ module Yast
             "<p><b>ACL Group</b> has various types and the description of ACL Group depends\non the particular type.</p>\n"
           ),
         "http_access"     => _(
-          "<p>In the <b>Access Control</b> table, access can be denied or allowed to ACL Groups.\n" +
-            "If there are more ACL Groups in one line, it means that access will be allowed\n" +
+          "<p>In the <b>Access Control</b> table, access can be denied or allowed to ACL Groups.\n" \
+            "If there are more ACL Groups in one line, it means that access will be allowed\n" \
             "or denied to members who belong to all ACL Groups at the same time.</p>\n"
         ) +
           _(
@@ -164,8 +164,8 @@ module Yast
             "<p><b>Cache Log</b> defines the file in which general information about your\ncache's behavior is logged.</p>\n"
           ) +
           _(
-            "<p><b>Cache Store Log</b> defines the location of the transaction log of all\n" +
-              "objects that are stored in the object store, as well as the time when an object\n" +
+            "<p><b>Cache Store Log</b> defines the location of the transaction log of all\n" \
+              "objects that are stored in the object store, as well as the time when an object\n" \
               "gets deleted. This option can be left empty.</p>\n"
           ) +
           _(
@@ -181,7 +181,7 @@ module Yast
         "miscellaneous"   => _(
           "<p><b>Administrator's email</b> is the address which will be added to any\nerror pages that are displayed to clients. Defaults to webmaster.</p>\n"
         )
-      } 
+      }
 
       # EOF
     end

--- a/src/include/squid/inits.rb
+++ b/src/include/squid/inits.rb
@@ -36,7 +36,6 @@ module Yast
       Yast.import "SquidACL"
       Yast.import "SquidErrorMessages"
 
-
       Yast.include include_target, "squid/helps.rb"
     end
 
@@ -54,11 +53,8 @@ module Yast
       nil
     end
 
-
-
-
-    #*******************  HTTP_PORT  ****************
-    def InitHttpPortsTable(key)
+    # *******************  HTTP_PORT  ****************
+    def InitHttpPortsTable(_key)
       items = []
       i = 0
 
@@ -92,8 +88,9 @@ module Yast
 
       nil
     end
+
     def InitAddEditHttpPortDialog(id_item)
-      if id_item != nil
+      if !id_item.nil?
         values = Squid.GetHttpPort(id_item)
 
         UI.ChangeWidget(Id("host"), :Value, Ops.get_string(values, "host", ""))
@@ -107,12 +104,10 @@ module Yast
 
       nil
     end
-    #*******************  HTTP_PORT END  ************
+    # *******************  HTTP_PORT END  ************
 
-
-
-    #****************  REFRESH_PATTERNS  ************
-    def InitRefreshPatternsTable(key)
+    # ****************  REFRESH_PATTERNS  ************
+    def InitRefreshPatternsTable(_key)
       items = []
       i = 0
 
@@ -146,8 +141,9 @@ module Yast
 
       nil
     end
+
     def InitAddEditRefreshPatternDialog(id_item)
-      if id_item != nil
+      if !id_item.nil?
         values = Squid.GetRefreshPattern(id_item)
 
         UI.ChangeWidget(
@@ -184,59 +180,56 @@ module Yast
 
       nil
     end
-    #****************  REFRESH_PATTERNS END  ********
+    # ****************  REFRESH_PATTERNS END  ********
 
-
-    #****************  CACHE DIALOG  ****************
-    def InitCache2Dialog(key)
+    # ****************  CACHE DIALOG  ****************
+    def InitCache2Dialog(_key)
       set = Convert.convert(
         Squid.GetSettings,
-        :from => "map <string, any>",
-        :to   => "map <string, list>"
+        from: "map <string, any>",
+        to:   "map <string, list>"
       )
       simpleInit(
-        {
-          "cache_mem"                   => Builtins.tointeger(
-            Ops.get_string(Ops.get(set, "cache_mem", []), 0, "")
-          ),
-          "cache_mem_units"             => Ops.get_string(
-            Ops.get(set, "cache_mem", []),
-            1,
-            ""
-          ),
-          "cache_max_object_size"       => Builtins.tointeger(
-            Ops.get_string(Ops.get(set, "maximum_object_size", []), 0, "")
-          ),
-          "cache_max_object_size_units" => Ops.get_string(
-            Ops.get(set, "maximum_object_size", []),
-            1,
-            ""
-          ),
-          "cache_min_object_size"       => Builtins.tointeger(
-            Ops.get_string(Ops.get(set, "minimum_object_size", []), 0, "")
-          ),
-          "cache_min_object_size_units" => Ops.get_string(
-            Ops.get(set, "minimum_object_size", []),
-            1,
-            ""
-          ),
-          "cache_swap_low"              => Builtins.tointeger(
-            Ops.get_string(Ops.get(set, "cache_swap_low", []), 0, "")
-          ),
-          "cache_swap_high"             => Builtins.tointeger(
-            Ops.get_string(Ops.get(set, "cache_swap_high", []), 0, "")
-          ),
-          "cache_replacement_policy"    => Ops.get_string(
-            Ops.get(set, "cache_replacement_policy", []),
-            0,
-            ""
-          ),
-          "memory_replacement_policy"   => Ops.get_string(
-            Ops.get(set, "memory_replacement_policy", []),
-            0,
-            ""
-          )
-        }
+        "cache_mem"                   => Builtins.tointeger(
+          Ops.get_string(Ops.get(set, "cache_mem", []), 0, "")
+        ),
+        "cache_mem_units"             => Ops.get_string(
+          Ops.get(set, "cache_mem", []),
+          1,
+          ""
+        ),
+        "cache_max_object_size"       => Builtins.tointeger(
+          Ops.get_string(Ops.get(set, "maximum_object_size", []), 0, "")
+        ),
+        "cache_max_object_size_units" => Ops.get_string(
+          Ops.get(set, "maximum_object_size", []),
+          1,
+          ""
+        ),
+        "cache_min_object_size"       => Builtins.tointeger(
+          Ops.get_string(Ops.get(set, "minimum_object_size", []), 0, "")
+        ),
+        "cache_min_object_size_units" => Ops.get_string(
+          Ops.get(set, "minimum_object_size", []),
+          1,
+          ""
+        ),
+        "cache_swap_low"              => Builtins.tointeger(
+          Ops.get_string(Ops.get(set, "cache_swap_low", []), 0, "")
+        ),
+        "cache_swap_high"             => Builtins.tointeger(
+          Ops.get_string(Ops.get(set, "cache_swap_high", []), 0, "")
+        ),
+        "cache_replacement_policy"    => Ops.get_string(
+          Ops.get(set, "cache_replacement_policy", []),
+          0,
+          ""
+        ),
+        "memory_replacement_policy"   => Ops.get_string(
+          Ops.get(set, "memory_replacement_policy", []),
+          0,
+          ""
+        )
       )
       UI.ChangeWidget(Id("cache_max_object_size"), :Notify, true)
       UI.ChangeWidget(Id("cache_min_object_size"), :Notify, true)
@@ -249,34 +242,31 @@ module Yast
       nil
     end
 
-    def InitCacheDirectoryDialog(key)
+    def InitCacheDirectoryDialog(_key)
       set = Convert.convert(
         Squid.GetSettings,
-        :from => "map <string, any>",
-        :to   => "map <string, list>"
+        from: "map <string, any>",
+        to:   "map <string, list>"
       )
       simpleInit(
-        {
-          "cache_dir" => Ops.get_string(Ops.get(set, "cache_dir", []), 1, ""),
-          "mbytes"    => Builtins.tointeger(
-            Ops.get_string(Ops.get(set, "cache_dir", []), 2, "")
-          ),
-          "l1dirs"    => Builtins.tointeger(
-            Ops.get_string(Ops.get(set, "cache_dir", []), 3, "")
-          ),
-          "l2dirs"    => Builtins.tointeger(
-            Ops.get_string(Ops.get(set, "cache_dir", []), 4, "")
-          )
-        }
+        "cache_dir" => Ops.get_string(Ops.get(set, "cache_dir", []), 1, ""),
+        "mbytes"    => Builtins.tointeger(
+          Ops.get_string(Ops.get(set, "cache_dir", []), 2, "")
+        ),
+        "l1dirs"    => Builtins.tointeger(
+          Ops.get_string(Ops.get(set, "cache_dir", []), 3, "")
+        ),
+        "l2dirs"    => Builtins.tointeger(
+          Ops.get_string(Ops.get(set, "cache_dir", []), 4, "")
+        )
       )
 
       nil
     end
-    #****************  CACHE DIALOG END  ************
+    # ****************  CACHE DIALOG END  ************
 
-
-    #****************  ACL  *************************
-    def InitACLGroupsTable(key)
+    # ****************  ACL  *************************
+    def InitACLGroupsTable(_key)
       items = []
       i = 0
       sup_acls = SquidACL.SupportedACLs
@@ -309,9 +299,8 @@ module Yast
       nil
     end
 
-
     def InitAddEditACLDialog(id_item)
-      if id_item != nil
+      if !id_item.nil?
         acl = Squid.GetACL(id_item)
         UI.ChangeWidget(Id("name"), :Value, Ops.get_string(acl, "name", ""))
         UI.ChangeWidget(Id("type"), :Value, Ops.get_string(acl, "type", ""))
@@ -319,11 +308,10 @@ module Yast
 
       nil
     end
-    #****************  ACL END  *********************
+    # ****************  ACL END  *********************
 
-
-    #****************  HTTP_ACCESS  *****************
-    def InitHttpAccessTable(key)
+    # ****************  HTTP_ACCESS  *****************
+    def InitHttpAccessTable(_key)
       items = []
       i = 0
 
@@ -355,12 +343,11 @@ module Yast
       nil
     end
 
-
     def InitAddEditHttpAccessDialog(id_item)
       items = []
       acls_items = []
 
-      if id_item != nil
+      if !id_item.nil?
         http_access = Squid.GetHttpAccess(id_item)
         i = 0
 
@@ -388,8 +375,8 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           UI.QueryWidget(Id("acls"), :Items),
-          :from => "any",
-          :to   => "list <term>"
+          from: "any",
+          to:   "list <term>"
         )
       ) do |value|
         acls_items = Builtins.add(acls_items, Ops.get_string(value, 2, ""))
@@ -397,12 +384,12 @@ module Yast
 
       Builtins.foreach(Squid.GetACLs) do |value|
         if !Builtins.contains(
-            items,
-            Item(
-              Id(Ops.get_string(value, "name", "")),
-              Ops.get_string(value, "name", "")
-            )
-          ) &&
+          items,
+          Item(
+            Id(Ops.get_string(value, "name", "")),
+            Ops.get_string(value, "name", "")
+          )
+        ) &&
             !Builtins.contains(acls_items, Ops.get_string(value, "name", ""))
           items = Builtins.add(
             items,
@@ -418,79 +405,69 @@ module Yast
 
       nil
     end
-    #****************  HTTP_ACCESS END  *************
+    # ****************  HTTP_ACCESS END  *************
 
-
-
-
-    #*********  LOGGING AND TIMETOUS DIALOG  ********
-    def InitLoggingFrame(key)
+    # *********  LOGGING AND TIMETOUS DIALOG  ********
+    def InitLoggingFrame(_key)
       set = Convert.convert(
         Squid.GetSettings,
-        :from => "map <string, any>",
-        :to   => "map <string, list>"
+        from: "map <string, any>",
+        to:   "map <string, list>"
       )
       simpleInit(
-        {
-          "access_log"        => Ops.get_string(
-            Ops.get(set, "access_log", []),
-            0,
-            ""
-          ),
-          "cache_log"         => Ops.get_string(
-            Ops.get(set, "cache_log", []),
-            0,
-            ""
-          ),
-          "cache_store_log"   => Ops.get_string(
-            Ops.get(set, "cache_store_log", []),
-            0,
-            ""
-          )
-        }
+        "access_log"      => Ops.get_string(
+          Ops.get(set, "access_log", []),
+          0,
+          ""
+        ),
+        "cache_log"       => Ops.get_string(
+          Ops.get(set, "cache_log", []),
+          0,
+          ""
+        ),
+        "cache_store_log" => Ops.get_string(
+          Ops.get(set, "cache_store_log", []),
+          0,
+          ""
+        )
       )
 
       nil
     end
 
-    def InitTimeoutsFrame(key)
+    def InitTimeoutsFrame(_key)
       set = Convert.convert(
         Squid.GetSettings,
-        :from => "map <string, any>",
-        :to   => "map <string, list>"
+        from: "map <string, any>",
+        to:   "map <string, list>"
       )
       simpleInit(
-        {
-          "connect_timeout"       => Builtins.tointeger(
-            Ops.get_string(Ops.get(set, "connect_timeout", []), 0, "")
-          ),
-          "connect_timeout_units" => Ops.get_string(
-            Ops.get(set, "connect_timeout", []),
-            1,
-            ""
-          ),
-          "client_lifetime"       => Builtins.tointeger(
-            Ops.get_string(Ops.get(set, "client_lifetime", []), 0, "")
-          ),
-          "client_lifetime_units" => Ops.get_string(
-            Ops.get(set, "client_lifetime", []),
-            1,
-            ""
-          )
-        }
+        "connect_timeout"       => Builtins.tointeger(
+          Ops.get_string(Ops.get(set, "connect_timeout", []), 0, "")
+        ),
+        "connect_timeout_units" => Ops.get_string(
+          Ops.get(set, "connect_timeout", []),
+          1,
+          ""
+        ),
+        "client_lifetime"       => Builtins.tointeger(
+          Ops.get_string(Ops.get(set, "client_lifetime", []), 0, "")
+        ),
+        "client_lifetime_units" => Ops.get_string(
+          Ops.get(set, "client_lifetime", []),
+          1,
+          ""
+        )
       )
 
       nil
     end
-    #*********  LOGGING AND TIMETOUS DIALOG END  ****
+    # *********  LOGGING AND TIMETOUS DIALOG END  ****
 
-
-    def InitMiscellaneousFrame(key)
+    def InitMiscellaneousFrame(_key)
       simpleInit(
-        {
-          "cache_mgr"   => Ops.get(Squid.GetSetting("cache_mgr"), 0, ""),
-          "ftp_passive" => Ops.get(Squid.GetSetting("ftp_passive"), 0, "") == "on" ? true : false
-        }
+        "cache_mgr"   => Ops.get(Squid.GetSetting("cache_mgr"), 0, ""),
+        "ftp_passive" => Ops.get(Squid.GetSetting("ftp_passive"), 0, "") == "on" ? true : false
       )
       UI.ChangeWidget(
         Id("error_language"),

--- a/src/include/squid/popup_dialogs.rb
+++ b/src/include/squid/popup_dialogs.rb
@@ -44,9 +44,7 @@ module Yast
     def AddEditHttpPortDialog(id_item)
       ui = nil
       ret = false
-      label = id_item.nil? ?
-        _("Add New HTTP Port") :
-        _("Edit Current HTTP Port")
+      label = id_item.nil? ? _("Add New HTTP Port") : _("Edit Current HTTP Port")
       contents = VBox(
         Label(label),
         VSpacing(0.5),
@@ -90,9 +88,7 @@ module Yast
     def AddEditRefreshPatternDialog(id_item)
       ret = false
       ui = nil
-      label = id_item.nil? ?
-        _("Add New Refresh Pattern") :
-        _("Edit Current refresh Pattern")
+      label = id_item.nil? ? _("Add New Refresh Pattern") : _("Edit Current refresh Pattern")
       tmp = nil
 
       contents = VBox(
@@ -156,7 +152,7 @@ module Yast
     # ****************  CACHE END  *******************
 
     # ****************  ACCESS CONTROL  **************
-    def addItemToAddEditHttpAccessDialog(_not, item)
+    def addItemToAddEditHttpAccessDialog(acl_not, item)
       items = []
 
       i = 0
@@ -177,7 +173,7 @@ module Yast
         )
         i = Ops.add(i, 1)
       end
-      items = Builtins.add(items, Item(Id(i), _not == true ? "not" : "", item))
+      items = Builtins.add(items, Item(Id(i), acl_not == true ? "not" : "", item))
       UI.ChangeWidget(Id("acls"), :Items, items)
 
       nil
@@ -217,8 +213,7 @@ module Yast
       ret = false
       ui = nil
       acl = ""
-      _not = false
-      tmp = nil
+      acl_not = false
       tmp_term = nil
       id_acl = 0
       label = id_item.nil? ? _("Add New HTTP Access") : _("Edit HTTP Access")
@@ -280,9 +275,9 @@ module Yast
           end
         elsif ui == :add
           acl = Convert.to_string(UI.QueryWidget(Id("acl"), :Value))
-          _not = Convert.to_boolean(UI.QueryWidget(Id("acl_not"), :Value))
+          acl_not = Convert.to_boolean(UI.QueryWidget(Id("acl_not"), :Value))
           if Ops.greater_than(Builtins.size(acl), 0)
-            addItemToAddEditHttpAccessDialog(_not, acl)
+            addItemToAddEditHttpAccessDialog(acl_not, acl)
             InitAddEditHttpAccessDialog(nil)
           end
         elsif ui == :del

--- a/src/include/squid/popup_dialogs.rb
+++ b/src/include/squid/popup_dialogs.rb
@@ -39,12 +39,12 @@ module Yast
       Yast.include include_target, "squid/helper_functions.rb"
     end
 
-    #****************  HTTP PORT  *******************
+    # ****************  HTTP PORT  *******************
     # returns true if something added/edited otherwise false
     def AddEditHttpPortDialog(id_item)
       ui = nil
       ret = false
-      label = id_item == nil ?
+      label = id_item.nil? ?
         _("Add New HTTP Port") :
         _("Edit Current HTTP Port")
       contents = VBox(
@@ -67,7 +67,7 @@ module Yast
 
       InitAddEditHttpPortDialog(id_item)
 
-      while true
+      loop do
         ui = UI.UserInput
 
         if ui == :abort || ui == :cancel
@@ -84,14 +84,13 @@ module Yast
       UI.CloseDialog
       ret
     end
-    #****************  HTTP PORT END  ***************
+    # ****************  HTTP PORT END  ***************
 
-
-    #****************  CACHE  ***********************
+    # ****************  CACHE  ***********************
     def AddEditRefreshPatternDialog(id_item)
       ret = false
       ui = nil
-      label = id_item == nil ?
+      label = id_item.nil? ?
         _("Add New Refresh Pattern") :
         _("Edit Current refresh Pattern")
       tmp = nil
@@ -122,7 +121,7 @@ module Yast
 
       InitAddEditRefreshPatternDialog(id_item)
 
-      while true
+      loop do
         ui = UI.UserInput
 
         if ui == :cancel || ui == :abort
@@ -135,17 +134,17 @@ module Yast
           end
         elsif ui == "min"
           if Ops.greater_than(
-              Convert.to_integer(tmp),
-              Convert.to_integer(UI.QueryWidget(Id("max"), :Value))
-            )
+            Convert.to_integer(tmp),
+            Convert.to_integer(UI.QueryWidget(Id("max"), :Value))
+          )
             UI.ChangeWidget(Id("max"), :Value, tmp)
           end
         elsif ui == "max"
           tmp = UI.QueryWidget(Id("max"), :Value)
           if Ops.greater_than(
-              Convert.to_integer(UI.QueryWidget(Id("min"), :Value)),
-              Convert.to_integer(tmp)
-            )
+            Convert.to_integer(UI.QueryWidget(Id("min"), :Value)),
+            Convert.to_integer(tmp)
+          )
             UI.ChangeWidget(Id("min"), :Value, tmp)
           end
         end
@@ -154,10 +153,9 @@ module Yast
       UI.CloseDialog
       ret
     end
-    #****************  CACHE END  *******************
+    # ****************  CACHE END  *******************
 
-
-    #****************  ACCESS CONTROL  **************
+    # ****************  ACCESS CONTROL  **************
     def addItemToAddEditHttpAccessDialog(_not, item)
       items = []
 
@@ -165,8 +163,8 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           UI.QueryWidget(Id("acls"), :Items),
-          :from => "any",
-          :to   => "list <term>"
+          from: "any",
+          to:   "list <term>"
         )
       ) do |value|
         items = Builtins.add(
@@ -184,6 +182,7 @@ module Yast
 
       nil
     end
+
     def delItemFromAddEditHttpAccessDialog(id_item)
       items = []
 
@@ -191,8 +190,8 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           UI.QueryWidget(Id("acls"), :Items),
-          :from => "any",
-          :to   => "list <term>"
+          from: "any",
+          to:   "list <term>"
         )
       ) do |value|
         if Ops.get(value, 0) != Id(id_item)
@@ -214,7 +213,6 @@ module Yast
       id_item
     end
 
-
     def AddEditHttpAccessDialog(id_item)
       ret = false
       ui = nil
@@ -223,7 +221,7 @@ module Yast
       tmp = nil
       tmp_term = nil
       id_acl = 0
-      label = id_item == nil ? _("Add New HTTP Access") : _("Edit HTTP Access")
+      label = id_item.nil? ? _("Add New HTTP Access") : _("Edit HTTP Access")
       contents = VBox(
         Label(label),
         VSpacing(0.5),
@@ -232,7 +230,7 @@ module Yast
           _("Allow/Deny"),
           [Item(Id("allow"), _("Allow")), Item(Id("deny"), _("Deny"))]
         ),
-        #`VSpacing(),
+        # `VSpacing(),
         MinSize(
           25,
           7,
@@ -269,7 +267,7 @@ module Yast
 
       InitAddEditHttpAccessDialog(id_item)
 
-      while true
+      loop do
         ui = UI.UserInput
 
         if ui == :cancel || ui == :abort
@@ -307,19 +305,17 @@ module Yast
         end
       end
 
-
       UI.CloseDialog
 
       ret
     end
-
 
     def AddEditACLDialog(id_item)
       ret = false
       ui = nil
       orig_type = ""
       type = ""
-      label = id_item == nil ? _("Add New ACL Group") : _("Edit ACL Group")
+      label = id_item.nil? ? _("Add New ACL Group") : _("Edit ACL Group")
       contents = HBox(
         HWeight(30, RichText(Id("help_text"), "")),
         HWeight(
@@ -354,7 +350,7 @@ module Yast
       SquidACL.Replace(:replace_point, orig_type)
       SquidACL.InitWidget(orig_type, id_item, "help_text")
 
-      while true
+      loop do
         ui = UI.UserInput
 
         if ui == :cancel || ui == :abort
@@ -375,7 +371,6 @@ module Yast
           end
         end
       end
-
 
       UI.CloseDialog
 

--- a/src/include/squid/store_del.rb
+++ b/src/include/squid/store_del.rb
@@ -45,7 +45,7 @@ module Yast
       Yast.include include_target, "squid/helper_functions.rb"
     end
 
-    #****************  HTTP_PORT  *******************
+    # ****************  HTTP_PORT  *******************
     def StoreDataFromAddEditHttpPortDialog(id_item)
       ok = true
       host = Convert.to_string(UI.QueryWidget(Id("host"), :Value))
@@ -76,9 +76,8 @@ module Yast
         ok = false
       end
 
-
       if ok
-        if id_item == nil
+        if id_item.nil?
           Squid.AddHttpPort(host, port, transparent)
         else
           Squid.ModifyHttpPort(id_item, host, port, transparent)
@@ -97,11 +96,9 @@ module Yast
       end
       id_item
     end
-    #****************  HTTP_PORT END  ***************
+    # ****************  HTTP_PORT END  ***************
 
-
-
-    #*************  REFRESH_PATTERNS  ***************
+    # *************  REFRESH_PATTERNS  ***************
     def StoreDataFromAddEditRefreshPatternDialog(id_item)
       ok = true
       regexp = Convert.to_string(UI.QueryWidget(Id("regexp"), :Value))
@@ -113,7 +110,7 @@ module Yast
       )
 
       if Ops.greater_than(Builtins.size(regexp), 0)
-        if id_item == nil
+        if id_item.nil?
           Squid.AddRefreshPattern(regexp, min, percent, max, case_sensitive)
         else
           Squid.ModifyRefreshPattern(
@@ -151,25 +148,24 @@ module Yast
       end
       ret
     end
+
     # returns new position or nil if not moved
     def MoveDownRefreshPattern(id_item)
       ret = nil
 
       if Ops.less_than(
-          id_item,
-          Ops.subtract(Builtins.size(Squid.GetRefreshPatterns), 1)
-        )
+        id_item,
+        Ops.subtract(Builtins.size(Squid.GetRefreshPatterns), 1)
+      )
         Squid.MoveRefreshPattern(id_item, Ops.add(id_item, 1))
         ret = Ops.add(id_item, 1)
       end
       ret
     end
-    #*************  REFRESH_PATTERNS END  ***********
+    # *************  REFRESH_PATTERNS END  ***********
 
-
-
-    #*************  CACHE DIALOG  *******************
-    def ValidateCache2Dialog(widget_id, event)
+    # *************  CACHE DIALOG  *******************
+    def ValidateCache2Dialog(_widget_id, event)
       event = deep_copy(event)
       ok = true
 
@@ -208,7 +204,8 @@ module Yast
 
       ok
     end
-    def StoreDataFromCache2Dialog(widget_id, event)
+
+    def StoreDataFromCache2Dialog(_widget_id, event)
       event = deep_copy(event)
       Squid.SetSetting(
         "cache_mem",
@@ -251,8 +248,7 @@ module Yast
       nil
     end
 
-
-    def ValidateCacheDirectoryDialog(widget_id, event)
+    def ValidateCacheDirectoryDialog(_widget_id, event)
       event = deep_copy(event)
       ok = true
 
@@ -284,9 +280,9 @@ module Yast
           )
 
           if Ops.greater_than(
-              max_obj_size,
-              Ops.add(cache_mem, cache_dir_mbytes)
-            )
+            max_obj_size,
+            Ops.add(cache_mem, cache_dir_mbytes)
+          )
             ok = false
             Report.Error(
               _(
@@ -299,7 +295,8 @@ module Yast
 
       ok
     end
-    def StoreDataFromCacheDirectoryDialog(widget_id, event)
+
+    def StoreDataFromCacheDirectoryDialog(_widget_id, event)
       event = deep_copy(event)
       squid_cache_dir = Squid.GetSetting("cache_dir")
 
@@ -316,11 +313,9 @@ module Yast
 
       nil
     end
-    #*************  CACHE DIALOG END  ***************
+    # *************  CACHE DIALOG END  ***************
 
-
-
-    #*************  HTTP_ACCESS  ********************
+    # *************  HTTP_ACCESS  ********************
     def StoreDataFromAddEditHttpAccessDialog(id_item)
       ok = true
       allow = true
@@ -331,8 +326,8 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           UI.QueryWidget(Id("acls"), :Items),
-          :from => "any",
-          :to   => "list <term>"
+          from: "any",
+          to:   "list <term>"
         )
       ) do |value|
         tmp = Ops.get_string(value, 1, "") == "not" ? "!" : ""
@@ -341,7 +336,7 @@ module Yast
       end
 
       if Ops.greater_than(Builtins.size(acls), 0)
-        if id_item == nil
+        if id_item.nil?
           Squid.AddHttpAccess(allow, acls)
         else
           Squid.ModifyHttpAccess(id_item, allow, acls)
@@ -353,6 +348,7 @@ module Yast
 
       ok
     end
+
     def DelFromHttpAccessTable(id_item)
       Squid.DelHttpAccess(id_item)
       if Ops.greater_or_equal(id_item, Builtins.size(Squid.GetHttpAccesses))
@@ -360,6 +356,7 @@ module Yast
       end
       id_item
     end
+
     def MoveUpHttpAccess(id_item)
       ret = nil
 
@@ -369,23 +366,22 @@ module Yast
       end
       ret
     end
+
     def MoveDownHttpAccess(id_item)
       ret = nil
 
       if Ops.less_than(
-          id_item,
-          Ops.subtract(Builtins.size(Squid.GetHttpAccesses), 1)
-        )
+        id_item,
+        Ops.subtract(Builtins.size(Squid.GetHttpAccesses), 1)
+      )
         Squid.MoveHttpAccess(id_item, Ops.add(id_item, 1))
         ret = Ops.add(id_item, 1)
       end
       ret
     end
-    #*************  HTTP_ACCESS END  ****************
+    # *************  HTTP_ACCESS END  ****************
 
-
-
-    #*************  ACL  ****************************
+    # *************  ACL  ****************************
     def StoreDataFromAddEditACLDialog(id_item)
       ok = true
 
@@ -398,7 +394,7 @@ module Yast
       affected_options = []
       num_acls = nil
       old_name = nil
-      if id_item != nil
+      if !id_item.nil?
         affected_options = Squid.ACLIsUsedBy(id_item)
         num_acls = Squid.NumACLs(id_item)
         old_name = Ops.get_string(Squid.GetACL(id_item), "name", "")
@@ -407,10 +403,10 @@ module Yast
       if verification && Ops.greater_than(Builtins.size(name), 0)
         # test, if exists ACL with same name but different type
         existed_type = Squid.GetACLTypeByName(name)
-        if existed_type != nil && existed_type != type
+        if !existed_type.nil? && existed_type != type
           error = false
 
-          if id_item != nil
+          if !id_item.nil?
             numACLs = Squid.NumACLsByName(name)
             if name != old_name && Ops.greater_than(numACLs, 0) ||
                 name == old_name && Ops.greater_than(numACLs, 1)
@@ -443,10 +439,10 @@ module Yast
           end
         end
 
-        #verification where name is changed and this ACL has 1 occurrence
-        if ok && id_item != nil && old_name != name &&
+        # verification where name is changed and this ACL has 1 occurrence
+        if ok && !id_item.nil? && old_name != name &&
             Squid.NumACLs(id_item) == 1
-          #test if changed ACL is used in http_access option.
+          # test if changed ACL is used in http_access option.
           if Ops.greater_than(Builtins.size(affected_options), 0) &&
               Builtins.contains(affected_options, "http_access")
             Report.Error(
@@ -458,36 +454,36 @@ module Yast
                 )
             )
             ok = false
-          #test if changed ACL is used in other option (not managed by thid module)
+          # test if changed ACL is used in other option (not managed by thid module)
           elsif Ops.greater_than(Builtins.size(affected_options), 0)
             if !Report.AnyQuestion(
-                Label.WarningMsg,
+              Label.WarningMsg,
+              Ops.add(
                 Ops.add(
-                  Ops.add(
-                    _(
-                      "If you change the name of this ACL Group, these options might be affected: \n"
-                    ) + "    ",
-                    Builtins.mergestring(affected_options, ",\n    ")
-                  ),
-                  ".\n"
+                  _(
+                    "If you change the name of this ACL Group, these options might be affected: \n"
+                  ) + "    ",
+                  Builtins.mergestring(affected_options, ",\n    ")
                 ),
-                _("Change name anyway"),
-                _("Do not change name"),
-                :focus_no
-              )
+                ".\n"
+              ),
+              _("Change name anyway"),
+              _("Do not change name"),
+              :focus_no
+            )
               ok = false
             end
           end
         end
       elsif verification
-        #test, if name is filled
+        # test, if name is filled
         ok = false
         Report.Error(_("Name must not be empty."))
       else
         ok = false
       end
 
-      if ok && id_item == nil
+      if ok && id_item.nil?
         Squid.AddACL(name, type, options)
       elsif ok
         Squid.ModifyACL(id_item, name, type, options)
@@ -509,7 +505,7 @@ module Yast
           ok = false
 
           if Builtins.contains(affected_options, "http_access")
-            #Report::Error( _("This ACL Group can't be deleted.\nIt's used in Access Control table."));
+            # Report::Error( _("This ACL Group can't be deleted.\nIt's used in Access Control table."));
             Report.Error(
               _(
                 "You must not delete this ACL Group, because \nit is used in the Access Control table.\n"
@@ -528,14 +524,14 @@ module Yast
               ),
               ".\n"
             ) # +
-            #_("Are you sure you want to delete this ACL Group?");
+            # _("Are you sure you want to delete this ACL Group?");
             if Report.AnyQuestion(
-                Label.WarningMsg,
-                message,
-                _("Delete anyway"), #Label::YesButton(),
-                _("Do not delete"), #Label::NoButton(),
-                :focus_no
-              )
+              Label.WarningMsg,
+              message,
+              _("Delete anyway"), # Label::YesButton(),
+              _("Do not delete"), # Label::NoButton(),
+              :focus_no
+            )
               ok = true
             end
           end
@@ -551,13 +547,10 @@ module Yast
 
       id_item
     end
-    #*************  ACL END  ************************
+    # *************  ACL END  ************************
 
-
-
-
-    #*******  LOGGING AND TIMEOUTS DIALOG  **********
-    def ValidateLoggingFrame(widget_id, event)
+    # *******  LOGGING AND TIMEOUTS DIALOG  **********
+    def ValidateLoggingFrame(_widget_id, event)
       event = deep_copy(event)
       if Ops.get(event, "ID") != :abort
         ok = true
@@ -632,7 +625,8 @@ module Yast
       end
       true
     end
-    def StoreDataFromLoggingFrame(widget_id, event)
+
+    def StoreDataFromLoggingFrame(_widget_id, event)
       event = deep_copy(event)
       access_log = Convert.to_string(UI.QueryWidget(Id("access_log"), :Value))
       cache_log = Convert.to_string(UI.QueryWidget(Id("cache_log"), :Value))
@@ -651,7 +645,7 @@ module Yast
       nil
     end
 
-    def StoreDataFromTimeoutsFrame(widget_id, event)
+    def StoreDataFromTimeoutsFrame(_widget_id, event)
       event = deep_copy(event)
       Squid.SetSetting(
         "connect_timeout",
@@ -670,9 +664,9 @@ module Yast
 
       nil
     end
-    #*******  LOGGING AND TIMEOUTS DIALOG END  ******
+    # *******  LOGGING AND TIMEOUTS DIALOG END  ******
 
-    def ValidateMiscellaneousFrame(widget_id, event)
+    def ValidateMiscellaneousFrame(_widget_id, event)
       event = deep_copy(event)
       if Ops.get(event, "ID") != :abort
         ok = true
@@ -689,7 +683,8 @@ module Yast
       end
       true
     end
-    def StoreDataFromMiscellaneousFrame(widget_id, event)
+
+    def StoreDataFromMiscellaneousFrame(_widget_id, event)
       event = deep_copy(event)
       error_language = Convert.to_string(
         UI.QueryWidget(Id("error_language"), :Value)

--- a/src/include/squid/store_del.rb
+++ b/src/include/squid/store_del.rb
@@ -205,8 +205,7 @@ module Yast
       ok
     end
 
-    def StoreDataFromCache2Dialog(_widget_id, event)
-      event = deep_copy(event)
+    def StoreDataFromCache2Dialog(_widget_id, _event)
       Squid.SetSetting(
         "cache_mem",
         [
@@ -296,8 +295,7 @@ module Yast
       ok
     end
 
-    def StoreDataFromCacheDirectoryDialog(_widget_id, event)
-      event = deep_copy(event)
+    def StoreDataFromCacheDirectoryDialog(_widget_id, _event)
       squid_cache_dir = Squid.GetSetting("cache_dir")
 
       Squid.SetSetting(
@@ -318,11 +316,10 @@ module Yast
     # *************  HTTP_ACCESS  ********************
     def StoreDataFromAddEditHttpAccessDialog(id_item)
       ok = true
-      allow = true
       acls = []
       tmp = ""
-
       allow = UI.QueryWidget(Id("allow_deny"), :Value) == "allow" ? true : false
+
       Builtins.foreach(
         Convert.convert(
           UI.QueryWidget(Id("acls"), :Items),
@@ -392,11 +389,10 @@ module Yast
       verification = SquidACL.Verify(type)
 
       affected_options = []
-      num_acls = nil
       old_name = nil
+
       if !id_item.nil?
         affected_options = Squid.ACLIsUsedBy(id_item)
-        num_acls = Squid.NumACLs(id_item)
         old_name = Ops.get_string(Squid.GetACL(id_item), "name", "")
       end
 
@@ -626,8 +622,7 @@ module Yast
       true
     end
 
-    def StoreDataFromLoggingFrame(_widget_id, event)
-      event = deep_copy(event)
+    def StoreDataFromLoggingFrame(_widget_id, _event)
       access_log = Convert.to_string(UI.QueryWidget(Id("access_log"), :Value))
       cache_log = Convert.to_string(UI.QueryWidget(Id("cache_log"), :Value))
       cache_store_log = Convert.to_string(
@@ -645,8 +640,7 @@ module Yast
       nil
     end
 
-    def StoreDataFromTimeoutsFrame(_widget_id, event)
-      event = deep_copy(event)
+    def StoreDataFromTimeoutsFrame(_widget_id, _event)
       Squid.SetSetting(
         "connect_timeout",
         [
@@ -684,15 +678,12 @@ module Yast
       true
     end
 
-    def StoreDataFromMiscellaneousFrame(_widget_id, event)
-      event = deep_copy(event)
+    def StoreDataFromMiscellaneousFrame(_widget_id, _event)
       error_language = Convert.to_string(
         UI.QueryWidget(Id("error_language"), :Value)
       )
       cache_mgr = Convert.to_string(UI.QueryWidget(Id("cache_mgr"), :Value))
-      ftp_passive = Convert.to_boolean(
-        UI.QueryWidget(Id("ftp_passive"), :Value)
-      ) ? "on" : "off"
+      ftp_passive = Convert.to_boolean(UI.QueryWidget(Id("ftp_passive"), :Value)) ? "on" : "off"
 
       Squid.SetSetting(
         "error_directory",

--- a/src/include/squid/wizards.rb
+++ b/src/include/squid/wizards.rb
@@ -42,10 +42,10 @@ module Yast
     # Main workflow of the squid configuration
     # @return sequence result
     def MainSequence
-      aliases = { "main" => lambda { MainDialog() } }
+      aliases = { "main" => -> { MainDialog() } }
       sequence = {
         "ws_start" => "main",
-        "main"     => { :abort => :abort, :next => :next }
+        "main"     => { abort: :abort, next: :next }
       }
       ret = Sequencer.Run(aliases, sequence)
 
@@ -56,16 +56,16 @@ module Yast
     # @return sequence result
     def SquidSequence
       aliases = {
-        "read"  => [lambda { ReadDialog() }, true],
-        "main"  => lambda { MainSequence() },
-        "write" => [lambda { WriteDialog() }, true]
+        "read"  => [-> { ReadDialog() }, true],
+        "main"  => -> { MainSequence() },
+        "write" => [-> { WriteDialog() }, true]
       }
 
       sequence = {
         "ws_start" => "read",
-        "read"     => { :abort => :abort, :next => "main" },
-        "main"     => { :abort => :abort, :next => "write" },
-        "write"    => { :abort => :abort, :next => :next }
+        "read"     => { abort: :abort, next: "main" },
+        "main"     => { abort: :abort, next: "write" },
+        "write"    => { abort: :abort, next: :next }
       }
 
       Wizard.CreateDialog

--- a/src/modules/Squid.rb
+++ b/src/modules/Squid.rb
@@ -439,7 +439,6 @@ module Yast
       acl = Ops.get_string(GetACL(id_item), "name", "")
       return nil if Builtins.size(acl) == 0 # invalid id_item
 
-      params = []
       ret = []
 
       # options with format:
@@ -492,11 +491,9 @@ module Yast
           ) do |params2|
             params2 = Builtins.remove(params2, 0) # remove first param
             if Builtins.contains(format2, value)
-              if Ops.greater_than(Builtins.size(params2), 1)
-                params2 = Builtins.remove(params2, 0)
-              else
-                raise Break
-              end
+              raise Break unless Ops.greater_than(Builtins.size(params2), 1)
+
+              params2 = Builtins.remove(params2, 0)
             end
             if Builtins.contains(params2, acl) ||
                 Builtins.contains(params2, Ops.add("!", acl))
@@ -1323,8 +1320,6 @@ module Yast
         return true
       end
 
-      tcp_ports = GetHttpPortsOnly()
-
       begin
         Y2Firewall::Firewalld::Service.modify_ports(
           name:      @firewall_service_name,
@@ -1360,11 +1355,9 @@ module Yast
           ok = false
           Report.Error(Message.CannotStartService("squid"))
         end
-      else
-        if !Service.Restart("squid")
-          ok = false
-          Report.Error(Message.CannotRestartService("squid"))
-        end
+      elsif !Service.Restart("squid")
+        ok = false
+        Report.Error(Message.CannotRestartService("squid"))
       end
 
       ok
@@ -1560,9 +1553,7 @@ module Yast
             end
             tmp = Ops.add(
               Ops.add(tmp, Ops.get_string(value, "port", "")),
-              Ops.get_boolean(value, "transparent", false) ?
-                _(" (transparent)") :
-                ""
+              Ops.get_boolean(value, "transparent", false) ? _(" (transparent)") : ""
             )
             tmp = Ops.add(tmp, "</i>")
             summary = Summary.AddListItem(summary, tmp)

--- a/src/modules/Squid.rb
+++ b/src/modules/Squid.rb
@@ -51,13 +51,11 @@ module Yast
       # Defines name of service which is used by firewall when it's openning ports.
       @firewall_service_name = "squid"
 
-
       # Data was modified?
       @modified = false
 
       # Is service enabled?
       @service_enabled_on_startup = false
-
 
       # Map of all configuration settings except consequential. Format:
       # $[ "parameter name" : [ list of options (rest of line) ]
@@ -98,7 +96,6 @@ module Yast
       # ]
       @refresh_patterns = []
 
-
       # Map of all available parameters with defalut values.
       # $[ "parameter_name" : [ list of default options ],
       #    ...
@@ -128,15 +125,13 @@ module Yast
         "ftp_passive"               => ["on"]
       }
 
-
-
       # Write only, used during autoinstallation.
       # Don't run services and SuSEconfig, it's all done at one place.
       @write_only = false
 
       # Abort function
       # return boolean return true if abort
-      #global boolean() AbortFunction = GetModified;
+      # global boolean() AbortFunction = GetModified;
       @AbortFunction = nil
     end
 
@@ -144,17 +139,18 @@ module Yast
       @firewall_service_name
     end
 
-    #****************  HELP FUNCTIONS  **************
+    # ****************  HELP FUNCTIONS  **************
     # Same as splitstring(), but returns only non-empty strings.
     def split(str, delim)
       Builtins.filter(Builtins.splitstring(str, delim)) do |value|
         Ops.greater_than(Builtins.size(value), 0)
       end
     end
+
     # Verify and repair list of ACLs if something's wrong.
     def verifyACLs
-      #verification of ACLs
-      #There must not exist more ACLs with same name and different type
+      # verification of ACLs
+      # There must not exist more ACLs with same name and different type
       i = 0
       tested = []
       to_remove = []
@@ -168,12 +164,12 @@ module Yast
               if Ops.get_string(val, "name", "") ==
                   Ops.get_string(value, "name", "") &&
                   Ops.get_string(val, "type", "") !=
-                    Ops.get_string(value, "type", "")
+                      Ops.get_string(value, "type", "")
                 to_remove = Builtins.add(to_remove, ii)
               end
               ii = Ops.add(ii, 1)
             end
-            #delete all ACLs which has not type same as value["type"]:"" -
+            # delete all ACLs which has not type same as value["type"]:"" -
             # - it means type of first occurence of tested ACL
             Builtins.foreach(to_remove) do |val|
               @acls = Builtins.remove(@acls, val)
@@ -186,7 +182,6 @@ module Yast
 
       nil
     end
-
 
     def repairTimeoutPeriodUnits(old)
       ret = "seconds"
@@ -205,7 +200,6 @@ module Yast
       ret
     end
 
-
     # Function which sets permissions 'chmod 750' and 'chown squid:root'
     # to directory dir if exists.
     # If dir does not exist, function returns true;
@@ -219,22 +213,18 @@ module Yast
       end
 
       if Convert.to_integer(
-          SCR.Execute(path(".target.bash"), Ops.add("chown squid:root ", dir))
-        ) != 0 ||
+        SCR.Execute(path(".target.bash"), Ops.add("chown squid:root ", dir))
+      ) != 0 ||
           Convert.to_integer(
             SCR.Execute(path(".target.bash"), Ops.add("chmod 750 ", dir))
           ) != 0
         return false
-        #return (Popup::ContinueCancel(sformat(_("Unable to set correct permissions to directory %1."), dir)));
+        # return (Popup::ContinueCancel(sformat(_("Unable to set correct permissions to directory %1."), dir)));
       end
 
       true
     end
-    #****************  HELP FUNCTIONS END  **********
-
-
-
-
+    # ****************  HELP FUNCTIONS END  **********
 
     def SetDefaultValues
       @http_ports = [{ "host" => "", "port" => "3128", "transparent" => false }]
@@ -319,8 +309,6 @@ module Yast
       nil
     end
 
-
-
     def GetModified
       @modified
     end
@@ -341,8 +329,7 @@ module Yast
       @AbortFunction.call
     end
 
-
-    #****** SERVICE ******
+    # ****** SERVICE ******
 
     # @deprecated
     def IsServiceEnabled
@@ -356,9 +343,9 @@ module Yast
 
       nil
     end
-    #****** SERVICE END  *
+    # ****** SERVICE END  *
 
-    #****** ACL ******
+    # ****** ACL ******
     def GetACLs
       deep_copy(@acls)
     end
@@ -387,7 +374,7 @@ module Yast
       SetModified()
       @acls = Builtins.add(
         @acls,
-        { "name" => name, "type" => type, "options" => options }
+        "name" => name, "type" => type, "options" => options
       )
 
       nil
@@ -417,11 +404,10 @@ module Yast
       nil
     end
 
-
     # Returns number of occurences of ACL (definition lines) in config file.
     def NumACLs(id_item)
-      acl = Ops.get_string(Ops.get(@acls, id_item, {}), "name", "") #get name of acl
-      return nil if Builtins.size(acl) == 0 #invalid id_item
+      acl = Ops.get_string(Ops.get(@acls, id_item, {}), "name", "") # get name of acl
+      return nil if Builtins.size(acl) == 0 # invalid id_item
       ret = 0
 
       Builtins.foreach(@acls) do |value|
@@ -451,7 +437,7 @@ module Yast
     # any options are not affected.
     def ACLIsUsedBy(id_item)
       acl = Ops.get_string(GetACL(id_item), "name", "")
-      return nil if Builtins.size(acl) == 0 #invalid id_item
+      return nil if Builtins.size(acl) == 0 # invalid id_item
 
       params = []
       ret = []
@@ -463,7 +449,7 @@ module Yast
         "cache",
         "broken_vary_encoding",
         "follow_x_forwarded_for",
-        #"http_access", -> cached in this module !!!
+        # "http_access", -> cached in this module !!!
         "http_reply_access",
         "icp_access",
         "htcp_access",
@@ -492,16 +478,16 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           Builtins.merge(format1, format2),
-          :from => "list",
-          :to   => "list <string>"
+          from: "list",
+          to:   "list <string>"
         )
       ) do |value|
         if Builtins.contains(available_options, value)
           Builtins.foreach(
             Convert.convert(
               SCR.Read(Builtins.add(@squid_path, value)),
-              :from => "any",
-              :to   => "list <list <string>>"
+              from: "any",
+              to:   "list <list <string>>"
             )
           ) do |params2|
             params2 = Builtins.remove(params2, 0) # remove first param
@@ -521,7 +507,7 @@ module Yast
         end
       end
 
-      #http_access:
+      # http_access:
       Builtins.foreach(@http_accesses) do |value|
         if Builtins.contains(Ops.get_list(value, "acl", []), acl) ||
             Builtins.contains(Ops.get_list(value, "acl", []), Ops.add("!", acl))
@@ -534,9 +520,9 @@ module Yast
 
       deep_copy(ret)
     end
-    #****** ACL END ******
+    # ****** ACL END ******
 
-    #****** HTTP_ACCESS *****
+    # ****** HTTP_ACCESS *****
     def GetHttpAccesses
       deep_copy(@http_accesses)
     end
@@ -550,7 +536,7 @@ module Yast
       SetModified()
       @http_accesses = Builtins.add(
         @http_accesses,
-        { "allow" => allow, "acl" => acl }
+        "allow" => allow, "acl" => acl
       )
 
       nil
@@ -595,9 +581,9 @@ module Yast
 
       nil
     end
-    #****** HTTP_ACCESS END *****
+    # ****** HTTP_ACCESS END *****
 
-    #****** SETTINGS ****
+    # ****** SETTINGS ****
     def GetSettings
       deep_copy(@settings)
     end
@@ -618,9 +604,9 @@ module Yast
       nil
     end
 
-    #****** SETTINGS END ****
+    # ****** SETTINGS END ****
 
-    #*** REFRESH PATTERN ***
+    # *** REFRESH PATTERN ***
     def GetRefreshPatterns
       deep_copy(@refresh_patterns)
     end
@@ -633,13 +619,11 @@ module Yast
       SetModified()
       @refresh_patterns = Builtins.add(
         @refresh_patterns,
-        {
-          "regexp"         => regexp,
-          "min"            => min,
-          "percent"        => percent,
-          "max"            => max,
-          "case_sensitive" => case_sensitive
-        }
+        "regexp"         => regexp,
+        "min"            => min,
+        "percent"        => percent,
+        "max"            => max,
+        "case_sensitive" => case_sensitive
       )
 
       nil
@@ -692,9 +676,9 @@ module Yast
 
       nil
     end
-    #*** REFRESH PATTERN END ***
+    # *** REFRESH PATTERN END ***
 
-    #*** HTTP PORT ****
+    # *** HTTP PORT ****
     # Returns only list of configured ports (no hosts and so on)
     def GetHttpPortsOnly
       ret = []
@@ -718,7 +702,7 @@ module Yast
       SetModified()
       @http_ports = Builtins.add(
         @http_ports,
-        { "host" => host, "port" => port, "transparent" => transparent }
+        "host" => host, "port" => port, "transparent" => transparent
       )
 
       nil
@@ -746,12 +730,9 @@ module Yast
 
       nil
     end
-    #*** HTTP PORT END ****
+    # *** HTTP PORT END ****
 
-
-
-    #*******************  READ  *********************
-
+    # *******************  READ  *********************
 
     # Read setting of parameter http_port.
     #      http_port [hostname:]port [transparent]
@@ -766,13 +747,13 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           SCR.Read(Builtins.add(@squid_path, "http_port")),
-          :from => "any",
-          :to   => "list <list <string>>"
+          from: "any",
+          to:   "list <list <string>>"
         )
       ) do |value|
         tmp_http_port = {}
         tmp = []
-        #can parse only 'http_port hostname:port [transparent]'
+        # can parse only 'http_port hostname:port [transparent]'
         if Ops.less_than(Builtins.size(value), 1) ||
             Ops.greater_than(Builtins.size(value), 2)
           ok = false
@@ -788,7 +769,7 @@ module Yast
           Ops.set(tmp_http_port, "host", Ops.get_string(tmp, 0, ""))
           Ops.set(tmp_http_port, "port", Ops.get_string(tmp, 1, ""))
         end
-        #transparent option
+        # transparent option
         if Builtins.size(value) == 2 && Ops.get(value, 1, "") == "transparent"
           Ops.set(tmp_http_port, "transparent", true)
         end
@@ -810,8 +791,8 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           SCR.Read(Builtins.add(@squid_path, "http_access")),
-          :from => "any",
-          :to   => "list <list <string>>"
+          from: "any",
+          to:   "list <list <string>>"
         )
       ) do |value|
         tmp_http_access = {}
@@ -843,12 +824,12 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           SCR.Read(Builtins.add(@squid_path, "refresh_pattern")),
-          :from => "any",
-          :to   => "list <list <string>>"
+          from: "any",
+          to:   "list <list <string>>"
         )
       ) do |value|
         tmp_refresh_pattern = {}
-        #case-insesitive
+        # case-insesitive
         if Ops.get(value, 0, "") == "-i"
           Ops.set(tmp_refresh_pattern, "case_sensitive", false)
           value = Builtins.remove(value, 0)
@@ -881,7 +862,7 @@ module Yast
       ok = true
       tmp_acl = {}
 
-      #list of types which contains regular expression
+      # list of types which contains regular expression
       regexps = [
         "srcdom_regex",
         "dstdom_regex",
@@ -894,8 +875,8 @@ module Yast
       Builtins.foreach(
         Convert.convert(
           SCR.Read(Builtins.add(@squid_path, "acl")),
-          :from => "any",
-          :to   => "list <list <string>>"
+          from: "any",
+          to:   "list <list <string>>"
         )
       ) do |value|
         tmp_acl = {}
@@ -922,8 +903,8 @@ module Yast
                 Builtins.mergestring(
                   Convert.convert(
                     Builtins.remove(Ops.get_list(tmp_acl, "options", []), 0),
-                    :from => "list",
-                    :to   => "list <string>"
+                    from: "list",
+                    to:   "list <string>"
                   ),
                   " "
                 )
@@ -936,7 +917,7 @@ module Yast
               [Builtins.mergestring(Ops.get_list(tmp_acl, "options", []), " ")]
             )
           end
-        #format: acl aclname header_name [-i] list of regexps
+        # format: acl aclname header_name [-i] list of regexps
         elsif Ops.get_string(tmp_acl, "type", "") == "req_header" ||
             Ops.get_string(tmp_acl, "type", "") == "rep_header"
           if Ops.get(Ops.get_list(tmp_acl, "options", []), 1, "") == "-i"
@@ -952,8 +933,8 @@ module Yast
                       Builtins.remove(Ops.get_list(tmp_acl, "options", []), 0),
                       0
                     ),
-                    :from => "list",
-                    :to   => "list <string>"
+                    from: "list",
+                    to:   "list <string>"
                   ),
                   " "
                 )
@@ -968,8 +949,8 @@ module Yast
                 Builtins.mergestring(
                   Convert.convert(
                     Builtins.remove(Ops.get_list(tmp_acl, "options", []), 0),
-                    :from => "list",
-                    :to   => "list <string>"
+                    from: "list",
+                    to:   "list <string>"
                   ),
                   " "
                 )
@@ -995,10 +976,10 @@ module Yast
       Builtins.foreach(@parameters) do |key, value|
         tmp = Convert.convert(
           SCR.Read(Builtins.add(@squid_path, key)),
-          :from => "any",
-          :to   => "list <list <string>>"
+          from: "any",
+          to:   "list <list <string>>"
         )
-        #tmp = split(tmp[0]:"", " \t");
+        # tmp = split(tmp[0]:"", " \t");
         tmp = Ops.get_list(tmp, 0, [])
         if Ops.greater_than(Builtins.size(tmp), 0)
           Ops.set(@settings, key, tmp)
@@ -1007,7 +988,7 @@ module Yast
         end
       end
 
-      #special modification
+      # special modification
       Ops.set(
         @settings,
         "cache_replacement_policy",
@@ -1142,12 +1123,9 @@ module Yast
 
       ok
     end
-    #*******************  READ END  *****************
+    # *******************  READ END  *****************
 
-
-
-    #*******************  WRITE  ********************
-
+    # *******************  WRITE  ********************
 
     def writeHttpPorts
       ok = true
@@ -1191,8 +1169,8 @@ module Yast
         Ops.set(tmp, 1, Ops.get_string(value, "type", ""))
         tmp = Convert.convert(
           Builtins.merge(tmp, Ops.get_list(value, "options", [])),
-          :from => "list",
-          :to   => "list <string>"
+          from: "list",
+          to:   "list <string>"
         )
         scr = Builtins.add(scr, tmp)
       end
@@ -1202,7 +1180,6 @@ module Yast
 
       ok
     end
-
 
     def writeHttpAccesses
       ok = true
@@ -1218,8 +1195,8 @@ module Yast
         end
         tmp = Convert.convert(
           Builtins.merge(tmp, Ops.get_list(value, "acl", [])),
-          :from => "list",
-          :to   => "list <string>"
+          from: "list",
+          to:   "list <string>"
         )
         scr = Builtins.add(scr, tmp)
       end
@@ -1229,7 +1206,6 @@ module Yast
 
       ok
     end
-
 
     def writeRefreshPatterns
       ok = true
@@ -1255,7 +1231,6 @@ module Yast
 
       ok
     end
-
 
     def writeRestSetting
       ok = true
@@ -1352,7 +1327,7 @@ module Yast
 
       begin
         Y2Firewall::Firewalld::Service.modify_ports(
-          name: @firewall_service_name,
+          name:      @firewall_service_name,
           tcp_ports: GetHttpPortsOnly()
         )
       rescue Y2Firewall::Firewalld::Service::NotFound
@@ -1374,11 +1349,11 @@ module Yast
     # Returns true if squid was successfuly started
     def StartService
       ok = true
-      #verify config file
-      #if ((integer)SCR::Execute(.target.bash, "squid -k parse") != 0){
+      # verify config file
+      # if ((integer)SCR::Execute(.target.bash, "squid -k parse") != 0){
       #    y2error("Squid::Write - startService - 'squid -k parse' failed");
       #    return false;
-      #}
+      # }
 
       if !IsServiceRunning()
         if !Service.Start("squid")
@@ -1472,7 +1447,7 @@ module Yast
       return false if Abort()
       result
     end
-    #*******************  WRITE END  ****************
+    # *******************  WRITE END  ****************
 
     # Saves service status (start mode and starts/stops the service)
     #
@@ -1500,7 +1475,7 @@ module Yast
       end
     end
 
-    #******************  AUTOYAST  ******************
+    # ******************  AUTOYAST  ******************
 
     # Get all squid settings from the first parameter
     # (For use by autoinstallation.)
@@ -1508,7 +1483,7 @@ module Yast
     # @return [Boolean] True on success
     def Import(sett)
       sett = deep_copy(sett)
-      if sett == {} || sett == nil
+      if sett == {} || sett.nil?
         SetDefaultValues()
         SetModified()
         return true
@@ -1575,9 +1550,9 @@ module Yast
           Builtins.foreach(@http_ports) do |value|
             tmp = "<i>"
             if Ops.greater_than(
-                Builtins.size(Ops.get_string(value, "host", "")),
-                0
-              )
+              Builtins.size(Ops.get_string(value, "host", "")),
+              0
+            )
               tmp = Ops.add(
                 Ops.add(tmp, Ops.get_string(value, "host", "")),
                 ":"
@@ -1595,7 +1570,7 @@ module Yast
           summary = Summary.CloseList(summary)
         end
 
-        #Cache directory
+        # Cache directory
         summary = Summary.AddLine(
           summary,
           Ops.add(
@@ -1632,93 +1607,93 @@ module Yast
       @service ||= Yast2::SystemService.find("squid")
     end
 
-    publish :variable => :squid_path, :type => "path", :private => true
-    publish :variable => :sysconfig_file, :type => "string", :private => true
-    publish :variable => :firewall_service_name, :type => "string", :private => true
-    publish :function => :GetFirewallServiceName, :type => "string ()"
-    publish :variable => :modified, :type => "boolean", :private => true
-    publish :variable => :service_enabled_on_startup, :type => "boolean", :private => true
-    publish :variable => :settings, :type => "map <string, any>", :private => true
-    publish :variable => :http_ports, :type => "list <map <string, any>>", :private => true
-    publish :variable => :acls, :type => "list <map <string, any>>", :private => true
-    publish :variable => :http_accesses, :type => "list <map <string, any>>", :private => true
-    publish :variable => :refresh_patterns, :type => "list <map <string, any>>", :private => true
-    publish :variable => :parameters, :type => "map <string, list>", :private => true
-    publish :variable => :write_only, :type => "boolean"
-    publish :function => :split, :type => "list <string> (string, string)", :private => true
-    publish :function => :NumACLs, :type => "integer (integer)"
-    publish :function => :verifyACLs, :type => "void ()", :private => true
-    publish :function => :repairTimeoutPeriodUnits, :type => "string (string)", :private => true
-    publish :function => :setWritePremissionsToCacheDir, :type => "boolean (string)", :private => true
-    publish :function => :SetDefaultValues, :type => "void ()"
-    publish :function => :GetModified, :type => "boolean ()"
-    publish :function => :SetModified, :type => "void ()"
-    publish :variable => :AbortFunction, :type => "boolean ()"
-    publish :function => :Abort, :type => "boolean ()"
-    publish :function => :IsServiceEnabled, :type => "boolean ()"
-    publish :function => :SetServiceEnabled, :type => "void (boolean)"
-    publish :function => :GetACLs, :type => "list <map <string, any>> ()"
-    publish :function => :GetACL, :type => "map <string, any> (integer)"
-    publish :function => :GetACLType, :type => "string (integer)"
-    publish :function => :GetACLTypeByName, :type => "string (string)"
-    publish :function => :AddACL, :type => "void (string, string, list <string>)"
-    publish :function => :ModifyACL, :type => "void (integer, string, string, list <string>)"
-    publish :function => :DelACL, :type => "void (integer)"
-    publish :function => :NumACLsByName, :type => "integer (string)"
-    publish :function => :ACLIsUsedBy, :type => "list <string> (integer)"
-    publish :function => :GetHttpAccesses, :type => "list <map <string, any>> ()"
-    publish :function => :GetHttpAccess, :type => "map <string, any> (integer)"
-    publish :function => :AddHttpAccess, :type => "void (boolean, list <string>)"
-    publish :function => :ModifyHttpAccess, :type => "void (integer, boolean, list <string>)"
-    publish :function => :DelHttpAccess, :type => "void (integer)"
-    publish :function => :MoveHttpAccess, :type => "void (integer, integer)"
-    publish :function => :GetSettings, :type => "map <string, any> ()"
-    publish :function => :GetSetting, :type => "list <string> (string)"
-    publish :function => :SetSetting, :type => "void (string, list)"
-    publish :function => :GetRefreshPatterns, :type => "list <map <string, any>> ()"
-    publish :function => :GetRefreshPattern, :type => "map <string, any> (integer)"
-    publish :function => :AddRefreshPattern, :type => "void (string, string, string, string, boolean)"
-    publish :function => :ModifyRefreshPattern, :type => "void (integer, string, string, string, string, boolean)"
-    publish :function => :DelRefreshPattern, :type => "void (integer)"
-    publish :function => :MoveRefreshPattern, :type => "void (integer, integer)"
-    publish :function => :GetHttpPortsOnly, :type => "list <string> ()"
-    publish :function => :GetHttpPorts, :type => "list <map <string, any>> ()"
-    publish :function => :GetHttpPort, :type => "map <string, any> (integer)"
-    publish :function => :AddHttpPort, :type => "void (string, string, boolean)"
-    publish :function => :ModifyHttpPort, :type => "void (integer, string, string, boolean)"
-    publish :function => :DelHttpPort, :type => "void (integer)"
-    publish :function => :readHttpPorts, :type => "boolean ()", :private => true
-    publish :function => :readHttpAccesses, :type => "boolean ()", :private => true
-    publish :function => :readRefreshPatterns, :type => "boolean ()", :private => true
-    publish :function => :readACLs, :type => "boolean ()", :private => true
-    publish :function => :readRestSetting, :type => "boolean ()", :private => true
-    publish :function => :readServiceStatus, :type => "boolean ()", :private => true
-    publish :function => :readAllSettings, :type => "boolean ()", :private => true
-    publish :function => :Read, :type => "boolean ()"
-    publish :function => :writeHttpPorts, :type => "boolean ()", :private => true
-    publish :function => :writeACLs, :type => "boolean ()", :private => true
-    publish :function => :writeHttpAccesses, :type => "boolean ()", :private => true
-    publish :function => :writeRefreshPatterns, :type => "boolean ()", :private => true
-    publish :function => :writeRestSetting, :type => "boolean ()", :private => true
-    publish :function => :writePermissions, :type => "boolean ()", :private => true
-    publish :function => :writeAllSettings, :type => "boolean ()", :private => true
-    publish :function => :writeFirewallSettings, :type => "boolean ()", :private => true
-    publish :function => :IsServiceRunning, :type => "boolean ()"
-    publish :function => :StartService, :type => "boolean ()"
-    publish :function => :StopService, :type => "boolean ()"
-    publish :function => :EnableService, :type => "boolean ()"
-    publish :function => :DisableService, :type => "boolean ()"
-    publish :function => :Write, :type => "boolean ()"
-    publish :function => :Import, :type => "boolean (map)"
-    publish :function => :Export, :type => "map ()"
-    publish :function => :Summary, :type => "list ()"
-    publish :function => :AutoPackages, :type => "map ()"
+    publish variable: :squid_path, type: "path", private: true
+    publish variable: :sysconfig_file, type: "string", private: true
+    publish variable: :firewall_service_name, type: "string", private: true
+    publish function: :GetFirewallServiceName, type: "string ()"
+    publish variable: :modified, type: "boolean", private: true
+    publish variable: :service_enabled_on_startup, type: "boolean", private: true
+    publish variable: :settings, type: "map <string, any>", private: true
+    publish variable: :http_ports, type: "list <map <string, any>>", private: true
+    publish variable: :acls, type: "list <map <string, any>>", private: true
+    publish variable: :http_accesses, type: "list <map <string, any>>", private: true
+    publish variable: :refresh_patterns, type: "list <map <string, any>>", private: true
+    publish variable: :parameters, type: "map <string, list>", private: true
+    publish variable: :write_only, type: "boolean"
+    publish function: :split, type: "list <string> (string, string)", private: true
+    publish function: :NumACLs, type: "integer (integer)"
+    publish function: :verifyACLs, type: "void ()", private: true
+    publish function: :repairTimeoutPeriodUnits, type: "string (string)", private: true
+    publish function: :setWritePremissionsToCacheDir, type: "boolean (string)", private: true
+    publish function: :SetDefaultValues, type: "void ()"
+    publish function: :GetModified, type: "boolean ()"
+    publish function: :SetModified, type: "void ()"
+    publish variable: :AbortFunction, type: "boolean ()"
+    publish function: :Abort, type: "boolean ()"
+    publish function: :IsServiceEnabled, type: "boolean ()"
+    publish function: :SetServiceEnabled, type: "void (boolean)"
+    publish function: :GetACLs, type: "list <map <string, any>> ()"
+    publish function: :GetACL, type: "map <string, any> (integer)"
+    publish function: :GetACLType, type: "string (integer)"
+    publish function: :GetACLTypeByName, type: "string (string)"
+    publish function: :AddACL, type: "void (string, string, list <string>)"
+    publish function: :ModifyACL, type: "void (integer, string, string, list <string>)"
+    publish function: :DelACL, type: "void (integer)"
+    publish function: :NumACLsByName, type: "integer (string)"
+    publish function: :ACLIsUsedBy, type: "list <string> (integer)"
+    publish function: :GetHttpAccesses, type: "list <map <string, any>> ()"
+    publish function: :GetHttpAccess, type: "map <string, any> (integer)"
+    publish function: :AddHttpAccess, type: "void (boolean, list <string>)"
+    publish function: :ModifyHttpAccess, type: "void (integer, boolean, list <string>)"
+    publish function: :DelHttpAccess, type: "void (integer)"
+    publish function: :MoveHttpAccess, type: "void (integer, integer)"
+    publish function: :GetSettings, type: "map <string, any> ()"
+    publish function: :GetSetting, type: "list <string> (string)"
+    publish function: :SetSetting, type: "void (string, list)"
+    publish function: :GetRefreshPatterns, type: "list <map <string, any>> ()"
+    publish function: :GetRefreshPattern, type: "map <string, any> (integer)"
+    publish function: :AddRefreshPattern, type: "void (string, string, string, string, boolean)"
+    publish function: :ModifyRefreshPattern, type: "void (integer, string, string, string, string, boolean)"
+    publish function: :DelRefreshPattern, type: "void (integer)"
+    publish function: :MoveRefreshPattern, type: "void (integer, integer)"
+    publish function: :GetHttpPortsOnly, type: "list <string> ()"
+    publish function: :GetHttpPorts, type: "list <map <string, any>> ()"
+    publish function: :GetHttpPort, type: "map <string, any> (integer)"
+    publish function: :AddHttpPort, type: "void (string, string, boolean)"
+    publish function: :ModifyHttpPort, type: "void (integer, string, string, boolean)"
+    publish function: :DelHttpPort, type: "void (integer)"
+    publish function: :readHttpPorts, type: "boolean ()", private: true
+    publish function: :readHttpAccesses, type: "boolean ()", private: true
+    publish function: :readRefreshPatterns, type: "boolean ()", private: true
+    publish function: :readACLs, type: "boolean ()", private: true
+    publish function: :readRestSetting, type: "boolean ()", private: true
+    publish function: :readServiceStatus, type: "boolean ()", private: true
+    publish function: :readAllSettings, type: "boolean ()", private: true
+    publish function: :Read, type: "boolean ()"
+    publish function: :writeHttpPorts, type: "boolean ()", private: true
+    publish function: :writeACLs, type: "boolean ()", private: true
+    publish function: :writeHttpAccesses, type: "boolean ()", private: true
+    publish function: :writeRefreshPatterns, type: "boolean ()", private: true
+    publish function: :writeRestSetting, type: "boolean ()", private: true
+    publish function: :writePermissions, type: "boolean ()", private: true
+    publish function: :writeAllSettings, type: "boolean ()", private: true
+    publish function: :writeFirewallSettings, type: "boolean ()", private: true
+    publish function: :IsServiceRunning, type: "boolean ()"
+    publish function: :StartService, type: "boolean ()"
+    publish function: :StopService, type: "boolean ()"
+    publish function: :EnableService, type: "boolean ()"
+    publish function: :DisableService, type: "boolean ()"
+    publish function: :Write, type: "boolean ()"
+    publish function: :Import, type: "boolean (map)"
+    publish function: :Export, type: "map ()"
+    publish function: :Summary, type: "list ()"
+    publish function: :AutoPackages, type: "map ()"
 
-    private
+  private
 
-      def firewalld
-        Y2Firewall::Firewalld.instance
-      end
+    def firewalld
+      Y2Firewall::Firewalld.instance
+    end
   end
 
   Squid = SquidClass.new

--- a/src/modules/SquidACL.rb
+++ b/src/modules/SquidACL.rb
@@ -35,7 +35,7 @@ module Yast
 
       Yast.include self, "squid/SquidACL_local_functions.rb"
 
-      #**
+      # **
       # Unsupported ACLS:
       # * * * * * * * * * * *
       # ident, ident_regex,
@@ -67,14 +67,14 @@ module Yast
           "widget"       => Frame(
             _("src"),
             VBox(
-              #`TextEntry(`id("acl_addr1"), _("IP Address 1"), ""),
-              #`Label(" - "),
+              # `TextEntry(`id("acl_addr1"), _("IP Address 1"), ""),
+              # `Label(" - "),
               TextEntry(
                 Id("acl_addr"),
                 _("IP Address or Range of IP Addresses"),
                 ""
               ),
-              #`Label("/"),
+              # `Label("/"),
               TextEntry(Id("acl_mask"), _("Network Mask"), "")
             )
           ),
@@ -384,11 +384,9 @@ module Yast
     def getKeys(m)
       m = deep_copy(m)
       ret = []
-      Builtins.foreach(m) { |key, value| ret = Builtins.add(ret, key) }
+      Builtins.foreach(m) { |key, _value| ret = Builtins.add(ret, key) }
       deep_copy(ret)
     end
-
-
 
     # Returns list of supported ACLs.
     # It's necessary to have saved unsupported ACLs but do not handle with them.
@@ -416,13 +414,12 @@ module Yast
       deep_copy(items)
     end
 
-
     # Initialize widget of acl identified by id_acl_type.
     # If id_item is not nil, function initialize widgets by default values
     # from module Squid.
     def InitWidget(id_acl_type, id_item, help_widget_id)
       help_widget_id = deep_copy(help_widget_id)
-      if help_widget_id != nil
+      if !help_widget_id.nil?
         UI.ChangeWidget(
           Id(help_widget_id),
           :Value,
@@ -431,8 +428,8 @@ module Yast
       end
       func = Convert.convert(
         Ops.get(Ops.get(@acl_map, id_acl_type, {}), "widget_init"),
-        :from => "any",
-        :to   => "void (integer)"
+        from: "any",
+        to:   "void (integer)"
       )
       func.call(id_item)
 
@@ -450,37 +447,35 @@ module Yast
       nil
     end
 
-
     # This function call verification function joined with acl type
     # identified by id_acl_type.
     # Returns return value of verification function.
     def Verify(id_acl_type)
       func = Convert.convert(
         Ops.get(Ops.get(@acl_map, id_acl_type, {}), "verification"),
-        :from => "any",
-        :to   => "boolean ()"
+        from: "any",
+        to:   "boolean ()"
       )
       func.call
     end
-
 
     # Returns values from widget as list of options in correct form to store
     # them into Squid module.
     def GetOptions(id_acl_type)
       func = Convert.convert(
         Ops.get(Ops.get(@acl_map, id_acl_type, {}), "options"),
-        :from => "any",
-        :to   => "list <string> ()"
+        from: "any",
+        to:   "list <string> ()"
       )
       func.call
     end
 
-    publish :function => :SupportedACLs, :type => "list <string> ()"
-    publish :function => :GetTypesToComboBox, :type => "list <term> ()"
-    publish :function => :InitWidget, :type => "void (string, integer, any)"
-    publish :function => :Replace, :type => "void (any, string)"
-    publish :function => :Verify, :type => "boolean (string)"
-    publish :function => :GetOptions, :type => "list <string> (string)"
+    publish function: :SupportedACLs, type: "list <string> ()"
+    publish function: :GetTypesToComboBox, type: "list <term> ()"
+    publish function: :InitWidget, type: "void (string, integer, any)"
+    publish function: :Replace, type: "void (any, string)"
+    publish function: :Verify, type: "boolean (string)"
+    publish function: :GetOptions, type: "list <string> (string)"
   end
 
   SquidACL = SquidACLClass.new

--- a/src/modules/SquidErrorMessages.rb
+++ b/src/modules/SquidErrorMessages.rb
@@ -36,7 +36,6 @@ module Yast
 
       Yast.import "FileUtils"
 
-
       # format:
       #      $[ "language" : "path_to_directory",
       #         ....
@@ -93,20 +92,20 @@ module Yast
         "uz"      => _("Uzbek"),
         "vi"      => _("Vietnamese"),
         "zh-cn"   => _("Simplified Chinese"),
-        "zh-tw"   => _("Traditional Chinese"),
+        "zh-tw"   => _("Traditional Chinese")
       }
     end
 
     def read
-      #if err uninitialized else do nothing
+      # if err uninitialized else do nothing
       if Builtins.size(@err) == 0
         @err = {}
         dir = ""
         Builtins.foreach(
           Convert.convert(
             SCR.Read(path(".target.dir"), @err_msg_dir),
-            :from => "any",
-            :to   => "list <string>"
+            from: "any",
+            to:   "list <string>"
           )
         ) do |value|
           if FileUtils.IsDirectory(Ops.add(Ops.add(@err_msg_dir, "/"), value))
@@ -128,7 +127,7 @@ module Yast
       read
 
       ret = []
-      Builtins.foreach(@err) { |key, value| ret = Builtins.add(ret, key) }
+      Builtins.foreach(@err) { |key, _value| ret = Builtins.add(ret, key) }
       deep_copy(ret)
     end
 
@@ -136,11 +135,10 @@ module Yast
     def GetLanguagesToComboBox
       read
 
-      return GetLanguages().map do |language|
-          Item(Id(language), @trans_map[language] || language)
+      GetLanguages().map do |language|
+        Item(Id(language), @trans_map[language] || language)
       end
     end
-
 
     # Returns path to directory containing error messages in given language.
     def GetPath(language)
@@ -165,14 +163,14 @@ module Yast
       ret
     end
 
-    publish :variable => :err, :type => "map <string, string>", :private => true
-    publish :variable => :err_msg_dir, :type => "string", :private => true
-    publish :function => :read, :type => "void ()", :private => true
-    publish :function => :GetLanguages, :type => "list <string> ()"
-    publish :variable => :trans_map, :type => "map <string, string>", :private => true
-    publish :function => :GetLanguagesToComboBox, :type => "list <term> ()"
-    publish :function => :GetPath, :type => "string (string)"
-    publish :function => :GetLanguageFromPath, :type => "string (string)"
+    publish variable: :err, type: "map <string, string>", private: true
+    publish variable: :err_msg_dir, type: "string", private: true
+    publish function: :read, type: "void ()", private: true
+    publish function: :GetLanguages, type: "list <string> ()"
+    publish variable: :trans_map, type: "map <string, string>", private: true
+    publish function: :GetLanguagesToComboBox, type: "list <term> ()"
+    publish function: :GetPath, type: "string (string)"
+    publish function: :GetLanguageFromPath, type: "string (string)"
   end
 
   SquidErrorMessages = SquidErrorMessagesClass.new

--- a/testsuite/tests/Squid-Read.rb
+++ b/testsuite/tests/Squid-Read.rb
@@ -73,66 +73,65 @@ module Yast
       @EXECUTE = {
         "target" => {
           "bash_output" => {
-            "exit" => 0,
+            "exit"   => 0,
             "stdout" => "",
-            "stderr" => "",
+            "stderr" => ""
           }
         }
       }
 
       Yast.include self, "testsuite.rb"
-      #TESTSUITE_INIT([READ,WRITE,EXECUTE], nil);
+      # TESTSUITE_INIT([READ,WRITE,EXECUTE], nil);
 
       Yast.import "Squid"
 
       DUMP("Squid::readHttpPorts()")
-      TEST(lambda { Squid.readHttpPorts }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.readHttpPorts }, [@READ, @WRITE, @EXECUTE], nil)
       DUMP("Squid::http_ports")
-      TEST(lambda { Squid.http_ports }, [], nil)
+      TEST(-> { Squid.http_ports }, [], nil)
 
       DUMP("------------------------------")
 
       DUMP("Squid::readHttpAccesses()")
-      TEST(lambda { Squid.readHttpAccesses }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.readHttpAccesses }, [@READ, @WRITE, @EXECUTE], nil)
       DUMP("Squid::http_accesses")
-      TEST(lambda { Squid.http_accesses }, [], nil)
+      TEST(-> { Squid.http_accesses }, [], nil)
 
       DUMP("------------------------------")
 
       DUMP("Squid::readRefreshPatterns()")
-      TEST(lambda { Squid.readRefreshPatterns }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.readRefreshPatterns }, [@READ, @WRITE, @EXECUTE], nil)
       DUMP("Squid::refresh_patterns")
-      TEST(lambda { Squid.refresh_patterns }, [], nil)
+      TEST(-> { Squid.refresh_patterns }, [], nil)
 
       DUMP("------------------------------")
 
       DUMP("Squid::readACLs()")
-      TEST(lambda { Squid.readACLs }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.readACLs }, [@READ, @WRITE, @EXECUTE], nil)
       DUMP("Squid::acls")
-      TEST(lambda { Squid.acls }, [], nil)
+      TEST(-> { Squid.acls }, [], nil)
 
       DUMP("------------------------------")
 
       DUMP("Squid::readRestSetting()")
-      TEST(lambda { Squid.readRestSetting }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.readRestSetting }, [@READ, @WRITE, @EXECUTE], nil)
       DUMP("Squid::settings")
-      TEST(lambda { Squid.settings }, [], nil)
+      TEST(-> { Squid.settings }, [], nil)
 
       DUMP("------------------------------")
 
       DUMP("Squid::Read()")
-      TEST(lambda { Squid.Read }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.Read }, [@READ, @WRITE, @EXECUTE], nil)
       DUMP("Squid::settings")
-      TEST(lambda { Squid.settings }, [], nil)
+      TEST(-> { Squid.settings }, [], nil)
       DUMP("Squid::acls")
-      TEST(lambda { Squid.acls }, [], nil)
+      TEST(-> { Squid.acls }, [], nil)
       DUMP("Squid::refresh_patterns")
-      TEST(lambda { Squid.refresh_patterns }, [], nil)
+      TEST(-> { Squid.refresh_patterns }, [], nil)
       DUMP("Squid::http_accesses")
-      TEST(lambda { Squid.http_accesses }, [], nil)
+      TEST(-> { Squid.http_accesses }, [], nil)
       DUMP("Squid::http_ports")
-      TEST(lambda { Squid.http_ports }, [], nil)
-
+      TEST(-> { Squid.http_ports }, [], nil)
 
       # Testing of using default values:
       DUMP("------------------------------")
@@ -154,7 +153,7 @@ module Yast
       @READ = { "etc" => @READ }
 
       DUMP("Squid:Read()")
-      TEST(lambda { Squid.Read }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.Read }, [@READ, @WRITE, @EXECUTE], nil)
 
       DUMP(
         "Squid::settings[\"cache_mem\"]:[\"1\"] == Squid::parameters[\"cache_mem\"]:[\"2\"]"
@@ -162,8 +161,8 @@ module Yast
       TEST(lambda do
         Convert.convert(
           Ops.get(Squid.settings, "cache_mem") { ["1"] },
-          :from => "any",
-          :to   => "list <string>"
+          from: "any",
+          to:   "list <string>"
         ) ==
           Ops.get(Squid.parameters, "cache_mem") { ["2"] }
       end, [], nil)
@@ -174,8 +173,8 @@ module Yast
       TEST(lambda do
         Convert.convert(
           Ops.get(Squid.settings, "memory_replacement_policy") { ["1"] },
-          :from => "any",
-          :to   => "list <string>"
+          from: "any",
+          to:   "list <string>"
         ) ==
           Ops.get(Squid.parameters, "memory_replacement_policy") { ["2"] }
       end, [], nil)

--- a/testsuite/tests/Squid-Read.rb
+++ b/testsuite/tests/Squid-Read.rb
@@ -5,7 +5,7 @@ module Yast
     def main
       # testedfiles: Squid.ycp
 
-      @READ = {
+      @read = {
         "squid" => {
           "http_port"                 => [
             ["localhost:3128"],
@@ -67,10 +67,10 @@ module Yast
           "ftp_passive"               => [["on"]]
         }
       }
-      @READ = { "etc" => @READ }
+      @read = { "etc" => @read }
 
-      @WRITE = {}
-      @EXECUTE = {
+      @write = {}
+      @execute = {
         "target" => {
           "bash_output" => {
             "exit"   => 0,
@@ -86,42 +86,42 @@ module Yast
       Yast.import "Squid"
 
       DUMP("Squid::readHttpPorts()")
-      TEST(-> { Squid.readHttpPorts }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.readHttpPorts }, [@read, @write, @execute], nil)
       DUMP("Squid::http_ports")
       TEST(-> { Squid.http_ports }, [], nil)
 
       DUMP("------------------------------")
 
       DUMP("Squid::readHttpAccesses()")
-      TEST(-> { Squid.readHttpAccesses }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.readHttpAccesses }, [@read, @write, @execute], nil)
       DUMP("Squid::http_accesses")
       TEST(-> { Squid.http_accesses }, [], nil)
 
       DUMP("------------------------------")
 
       DUMP("Squid::readRefreshPatterns()")
-      TEST(-> { Squid.readRefreshPatterns }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.readRefreshPatterns }, [@read, @write, @execute], nil)
       DUMP("Squid::refresh_patterns")
       TEST(-> { Squid.refresh_patterns }, [], nil)
 
       DUMP("------------------------------")
 
       DUMP("Squid::readACLs()")
-      TEST(-> { Squid.readACLs }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.readACLs }, [@read, @write, @execute], nil)
       DUMP("Squid::acls")
       TEST(-> { Squid.acls }, [], nil)
 
       DUMP("------------------------------")
 
       DUMP("Squid::readRestSetting()")
-      TEST(-> { Squid.readRestSetting }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.readRestSetting }, [@read, @write, @execute], nil)
       DUMP("Squid::settings")
       TEST(-> { Squid.settings }, [], nil)
 
       DUMP("------------------------------")
 
       DUMP("Squid::Read()")
-      TEST(-> { Squid.Read }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.Read }, [@read, @write, @execute], nil)
       DUMP("Squid::settings")
       TEST(-> { Squid.settings }, [], nil)
       DUMP("Squid::acls")
@@ -136,24 +136,24 @@ module Yast
       # Testing of using default values:
       DUMP("------------------------------")
       DUMP("----testing defualt values----")
-      @READ = Ops.get_map(@READ, "etc", {})
+      @read = Ops.get_map(@read, "etc", {})
       Ops.set(
-        @READ,
+        @read,
         "squid",
-        Builtins.remove(Ops.get_map(@READ, "squid", {}), "cache_mem")
+        Builtins.remove(Ops.get_map(@read, "squid", {}), "cache_mem")
       )
       Ops.set(
-        @READ,
+        @read,
         "squid",
         Builtins.remove(
-          Ops.get_map(@READ, "squid", {}),
+          Ops.get_map(@read, "squid", {}),
           "memory_replacement_policy"
         )
       )
-      @READ = { "etc" => @READ }
+      @read = { "etc" => @read }
 
       DUMP("Squid:Read()")
-      TEST(-> { Squid.Read }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.Read }, [@read, @write, @execute], nil)
 
       DUMP(
         "Squid::settings[\"cache_mem\"]:[\"1\"] == Squid::parameters[\"cache_mem\"]:[\"2\"]"

--- a/testsuite/tests/Squid.rb
+++ b/testsuite/tests/Squid.rb
@@ -75,9 +75,9 @@ module Yast
       @EXECUTE = {
         "target" => {
           "bash_output" => {
-            "exit" => 0,
+            "exit"   => 0,
             "stdout" => "",
-            "stderr" => "",
+            "stderr" => ""
           }
         }
       }
@@ -87,75 +87,72 @@ module Yast
 
       Squid.Read
 
-
       DUMP("==================================================")
       DUMP("=====================  ACL  ======================")
       DUMP("==================================================")
 
       DUMP("")
       DUMP("GetACLs()")
-      TEST(lambda { Squid.GetACLs }, [], nil)
+      TEST(-> { Squid.GetACLs }, [], nil)
 
       DUMP("")
       DUMP("GetACL(0)")
-      TEST(lambda { Squid.GetACL(0) }, [], nil)
+      TEST(-> { Squid.GetACL(0) }, [], nil)
       DUMP("GetACL(2)")
-      TEST(lambda { Squid.GetACL(2) }, [], nil)
+      TEST(-> { Squid.GetACL(2) }, [], nil)
       DUMP("GetACL(100) - out of range")
-      TEST(lambda { Squid.GetACL(100) }, [], nil)
+      TEST(-> { Squid.GetACL(100) }, [], nil)
 
       DUMP("++++++++++++++++++++++++++++++++++++++++++++++++++")
 
       DUMP("")
       DUMP("AddACL(\"name\", \"type\", [\"list\", \"of\", \"options\"])")
-      TEST(lambda { Squid.AddACL("name", "type", ["list", "of", "options"]) }, [], nil)
-      TEST(lambda { Squid.GetACL(Ops.subtract(Builtins.size(Squid.GetACLs), 1)) }, [], nil)
+      TEST(-> { Squid.AddACL("name", "type", ["list", "of", "options"]) }, [], nil)
+      TEST(-> { Squid.GetACL(Ops.subtract(Builtins.size(Squid.GetACLs), 1)) }, [], nil)
 
       DUMP("")
       DUMP("ModifyACL(0, \"QUERY2\", \"urlpath_regex\", [\"cgi-bin \\? aaa\"])")
-      TEST(lambda { Squid.GetACL(0) }, [], nil)
+      TEST(-> { Squid.GetACL(0) }, [], nil)
       TEST(lambda do
         Squid.ModifyACL(0, "QUERY2", "urlpath_regex", ["cgi-bin \\? aaa"])
       end, [], nil)
-      TEST(lambda { Squid.GetACL(0) }, [], nil)
+      TEST(-> { Squid.GetACL(0) }, [], nil)
       TEST(lambda do
         Squid.ModifyACL(0, "QUERY", "urlpath_regex", ["cgi-bin \\?"])
       end, [], nil)
 
       DUMP("")
       DUMP("ModifyACL(100, \"A\", \"a\", [\"a\"]) - out of range")
-      TEST(lambda { Squid.GetACL(100) }, [], nil)
-      TEST(lambda { Squid.ModifyACL(100, "A", "a", ["a"]) }, [], nil)
-      TEST(lambda { Squid.GetACL(100) }, [], nil)
+      TEST(-> { Squid.GetACL(100) }, [], nil)
+      TEST(-> { Squid.ModifyACL(100, "A", "a", ["a"]) }, [], nil)
+      TEST(-> { Squid.GetACL(100) }, [], nil)
 
       DUMP("")
       DUMP("DelACL(1)")
-      TEST(lambda { Squid.GetACL(1) }, [], nil)
-      TEST(lambda { Squid.GetACL(2) }, [], nil)
-      TEST(lambda { Squid.DelACL(1) }, [], nil)
-      TEST(lambda { Squid.GetACL(1) }, [], nil)
+      TEST(-> { Squid.GetACL(1) }, [], nil)
+      TEST(-> { Squid.GetACL(2) }, [], nil)
+      TEST(-> { Squid.DelACL(1) }, [], nil)
+      TEST(-> { Squid.GetACL(1) }, [], nil)
 
       DUMP("")
       DUMP("DelACL(100) - out of range")
-      TEST(lambda { Squid.DelACL(100) }, [], nil)
-      TEST(lambda { Squid.GetACL(100) }, [], nil)
-      TEST(lambda { Squid.GetACL(0) }, [], nil)
+      TEST(-> { Squid.DelACL(100) }, [], nil)
+      TEST(-> { Squid.GetACL(100) }, [], nil)
+      TEST(-> { Squid.GetACL(0) }, [], nil)
 
       DUMP("++++++++++++++++++++++++++++++++++++++++++++++++++")
 
       DUMP("")
       DUMP("NumACLs(0)")
-      TEST(lambda { Squid.NumACLs(0) }, [], nil)
+      TEST(-> { Squid.NumACLs(0) }, [], nil)
       DUMP("NumACLs(10)")
-      TEST(lambda { Squid.NumACLs(10) }, [], nil)
+      TEST(-> { Squid.NumACLs(10) }, [], nil)
 
       DUMP("")
       DUMP("ACLIsUsedBy(0) - QUERY")
-      TEST(lambda { Squid.ACLIsUsedBy(0) }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.ACLIsUsedBy(0) }, [@READ, @WRITE, @EXECUTE], nil)
       DUMP("ACLIsUsedBy(1)")
-      TEST(lambda { Squid.ACLIsUsedBy(1) }, [@READ, @WRITE, @EXECUTE], nil)
-
-
+      TEST(-> { Squid.ACLIsUsedBy(1) }, [@READ, @WRITE, @EXECUTE], nil)
 
       DUMP("==================================================")
       DUMP("================  HTTP_ACCESS  ===================")
@@ -163,21 +160,21 @@ module Yast
 
       DUMP("")
       DUMP("GetHttpAccesses()")
-      TEST(lambda { Squid.GetHttpAccesses }, [], nil)
+      TEST(-> { Squid.GetHttpAccesses }, [], nil)
 
       DUMP("")
       DUMP("GetHttpAccess(0)")
-      TEST(lambda { Squid.GetHttpAccess(0) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(0) }, [], nil)
       DUMP("GetHttpAccess(2)")
-      TEST(lambda { Squid.GetHttpAccess(2) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(2) }, [], nil)
       DUMP("GetHttpAccess(100) - out of range")
-      TEST(lambda { Squid.GetHttpAccess(100) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(100) }, [], nil)
 
       DUMP("++++++++++++++++++++++++++++++++++++++++++++++++++")
 
       DUMP("")
       DUMP("AddHttpAccess(true, [\"list\", \"of\", \"acls\"])")
-      TEST(lambda { Squid.AddHttpAccess(true, ["list", "of", "acls"]) }, [], nil)
+      TEST(-> { Squid.AddHttpAccess(true, ["list", "of", "acls"]) }, [], nil)
       TEST(lambda do
         Squid.GetHttpAccess(
           Ops.subtract(Builtins.size(Squid.GetHttpAccesses), 1)
@@ -186,39 +183,37 @@ module Yast
 
       DUMP("")
       DUMP("ModifyHttpAccess(0, false, [\"manager\", \"locahost\"])")
-      TEST(lambda { Squid.GetHttpAccess(0) }, [], nil)
-      TEST(lambda { Squid.ModifyHttpAccess(0, false, ["manager", "localhost"]) }, [], nil)
-      TEST(lambda { Squid.GetHttpAccess(0) }, [], nil)
-      TEST(lambda { Squid.ModifyHttpAccess(0, true, ["manager", "localhost"]) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(0) }, [], nil)
+      TEST(-> { Squid.ModifyHttpAccess(0, false, ["manager", "localhost"]) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(0) }, [], nil)
+      TEST(-> { Squid.ModifyHttpAccess(0, true, ["manager", "localhost"]) }, [], nil)
 
       DUMP("")
       DUMP("ModifyHttpAccess(100, true, [\"a\"]) - out of range")
-      TEST(lambda { Squid.GetHttpAccess(100) }, [], nil)
-      TEST(lambda { Squid.ModifyHttpAccess(100, true, ["a"]) }, [], nil)
-      TEST(lambda { Squid.GetHttpAccess(100) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(100) }, [], nil)
+      TEST(-> { Squid.ModifyHttpAccess(100, true, ["a"]) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(100) }, [], nil)
 
       DUMP("")
       DUMP("DelHttpAccess(1)")
-      TEST(lambda { Squid.GetHttpAccess(1) }, [], nil)
-      TEST(lambda { Squid.GetHttpAccess(2) }, [], nil)
-      TEST(lambda { Squid.DelHttpAccess(1) }, [], nil)
-      TEST(lambda { Squid.GetHttpAccess(1) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(1) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(2) }, [], nil)
+      TEST(-> { Squid.DelHttpAccess(1) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(1) }, [], nil)
 
       DUMP("")
       DUMP("MoveHttpAccess(0,1)")
-      TEST(lambda { Squid.GetHttpAccess(0) }, [], nil)
-      TEST(lambda { Squid.GetHttpAccess(1) }, [], nil)
-      TEST(lambda { Squid.MoveHttpAccess(0, 1) }, [], nil)
-      TEST(lambda { Squid.GetHttpAccess(0) }, [], nil)
-      TEST(lambda { Squid.GetHttpAccess(1) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(0) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(1) }, [], nil)
+      TEST(-> { Squid.MoveHttpAccess(0, 1) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(0) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(1) }, [], nil)
 
       DUMP("")
       DUMP("DelHttpAccess(100) - out of range")
-      TEST(lambda { Squid.DelHttpAccess(100) }, [], nil)
-      TEST(lambda { Squid.GetHttpAccess(100) }, [], nil)
-      TEST(lambda { Squid.GetHttpAccess(0) }, [], nil)
-
-
+      TEST(-> { Squid.DelHttpAccess(100) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(100) }, [], nil)
+      TEST(-> { Squid.GetHttpAccess(0) }, [], nil)
 
       DUMP("==================================================")
       DUMP("=================   SETTINGS  ====================")
@@ -226,11 +221,11 @@ module Yast
 
       DUMP("")
       DUMP("GetSettings()")
-      TEST(lambda { Squid.GetSettings }, [], nil)
+      TEST(-> { Squid.GetSettings }, [], nil)
 
       DUMP("")
       DUMP("GetSetting(\"cache_dir\")")
-      TEST(lambda { Squid.GetSetting("cache_dir") }, [], nil)
+      TEST(-> { Squid.GetSetting("cache_dir") }, [], nil)
 
       DUMP("")
       DUMP(
@@ -239,23 +234,22 @@ module Yast
       TEST(lambda do
         Squid.SetSetting("cache_dir", ["uufs", "/var/", "10", "10", "10"])
       end, [], nil)
-      TEST(lambda { Squid.GetSetting("cache_dir") }, [], nil)
-
+      TEST(-> { Squid.GetSetting("cache_dir") }, [], nil)
 
       DUMP("==================================================")
       DUMP("==============  REFRESH_PATTERNS  ================")
       DUMP("==================================================")
       DUMP("")
       DUMP("GetRefreshPatterns()")
-      TEST(lambda { Squid.GetRefreshPatterns }, [], nil)
+      TEST(-> { Squid.GetRefreshPatterns }, [], nil)
 
       DUMP("")
       DUMP("GetRefreshPattern(0)")
-      TEST(lambda { Squid.GetRefreshPattern(0) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(0) }, [], nil)
       DUMP("GetRefreshPattern(2)")
-      TEST(lambda { Squid.GetRefreshPattern(2) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(2) }, [], nil)
       DUMP("GetRefreshPattern(100) - out of range")
-      TEST(lambda { Squid.GetRefreshPattern(100) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(100) }, [], nil)
 
       DUMP("++++++++++++++++++++++++++++++++++++++++++++++++++")
 
@@ -274,44 +268,42 @@ module Yast
       DUMP(
         "ModifyRefreshPattern(0, \"regexp\",  \"100\", \"100\", \"100\", false)"
       )
-      TEST(lambda { Squid.GetRefreshPattern(0) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(0) }, [], nil)
       TEST(lambda do
         Squid.ModifyRefreshPattern(0, "regexp", "100", "100", "100", false)
       end, [], nil)
-      TEST(lambda { Squid.GetRefreshPattern(0) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(0) }, [], nil)
 
       DUMP("")
       DUMP(
         "ModifyRefreshPattern(100, \"regexp\",  \"100\", \"100\", \"100\", false)"
       )
-      TEST(lambda { Squid.GetRefreshPattern(100) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(100) }, [], nil)
       TEST(lambda do
         Squid.ModifyRefreshPattern(100, "regexp", "100", "100", "100", false)
       end, [], nil)
-      TEST(lambda { Squid.GetRefreshPattern(100) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(100) }, [], nil)
 
       DUMP("")
       DUMP("DelRefreshPattern(1)")
-      TEST(lambda { Squid.GetRefreshPattern(1) }, [], nil)
-      TEST(lambda { Squid.GetRefreshPattern(2) }, [], nil)
-      TEST(lambda { Squid.DelRefreshPattern(1) }, [], nil)
-      TEST(lambda { Squid.GetRefreshPattern(1) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(1) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(2) }, [], nil)
+      TEST(-> { Squid.DelRefreshPattern(1) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(1) }, [], nil)
 
       DUMP("")
       DUMP("MoveRefreshPattern(0,1)")
-      TEST(lambda { Squid.GetRefreshPattern(0) }, [], nil)
-      TEST(lambda { Squid.GetRefreshPattern(1) }, [], nil)
-      TEST(lambda { Squid.MoveRefreshPattern(0, 1) }, [], nil)
-      TEST(lambda { Squid.GetRefreshPattern(0) }, [], nil)
-      TEST(lambda { Squid.GetRefreshPattern(1) }, [], nil)
-
+      TEST(-> { Squid.GetRefreshPattern(0) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(1) }, [], nil)
+      TEST(-> { Squid.MoveRefreshPattern(0, 1) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(0) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(1) }, [], nil)
 
       DUMP("")
       DUMP("DelRefreshPattern(100) - out of range")
-      TEST(lambda { Squid.DelRefreshPattern(100) }, [], nil)
-      TEST(lambda { Squid.GetRefreshPattern(100) }, [], nil)
-      TEST(lambda { Squid.GetRefreshPattern(0) }, [], nil)
-
+      TEST(-> { Squid.DelRefreshPattern(100) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(100) }, [], nil)
+      TEST(-> { Squid.GetRefreshPattern(0) }, [], nil)
 
       DUMP("==================================================")
       DUMP("=================  HTTP_PORT  ====================")
@@ -319,50 +311,49 @@ module Yast
 
       DUMP("")
       DUMP("GetHttpPorts()")
-      TEST(lambda { Squid.GetHttpPorts }, [], nil)
+      TEST(-> { Squid.GetHttpPorts }, [], nil)
 
       DUMP("")
       DUMP("GetHttpPort(0)")
-      TEST(lambda { Squid.GetHttpPort(0) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(0) }, [], nil)
       DUMP("GetHttpPort(2)")
-      TEST(lambda { Squid.GetHttpPort(2) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(2) }, [], nil)
       DUMP("GetHttpPort(100) - out of range")
-      TEST(lambda { Squid.GetHttpPort(100) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(100) }, [], nil)
 
       DUMP("++++++++++++++++++++++++++++++++++++++++++++++++++")
 
       DUMP("")
       DUMP("AddHttpPort(\"host\", \"port\", true)")
-      TEST(lambda { Squid.AddHttpPort("host", "port", true) }, [], nil)
+      TEST(-> { Squid.AddHttpPort("host", "port", true) }, [], nil)
       TEST(lambda do
         Squid.GetHttpPort(Ops.subtract(Builtins.size(Squid.GetHttpPorts), 1))
       end, [], nil)
 
       DUMP("")
       DUMP("ModifyHttpPort(0, \"host\", \"port\", true)")
-      TEST(lambda { Squid.GetHttpPort(0) }, [], nil)
-      TEST(lambda { Squid.ModifyHttpPort(0, "host", "port", true) }, [], nil)
-      TEST(lambda { Squid.GetHttpPort(0) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(0) }, [], nil)
+      TEST(-> { Squid.ModifyHttpPort(0, "host", "port", true) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(0) }, [], nil)
 
       DUMP("")
       DUMP("ModifyHttpPort(100, \"host\", \"port\", true)")
-      TEST(lambda { Squid.GetHttpPort(100) }, [], nil)
-      TEST(lambda { Squid.ModifyHttpPort(100, "host", "port", true) }, [], nil)
-      TEST(lambda { Squid.GetHttpPort(100) }, [], nil)
-
+      TEST(-> { Squid.GetHttpPort(100) }, [], nil)
+      TEST(-> { Squid.ModifyHttpPort(100, "host", "port", true) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(100) }, [], nil)
 
       DUMP("")
       DUMP("DelHttpPort(1)")
-      TEST(lambda { Squid.GetHttpPort(1) }, [], nil)
-      TEST(lambda { Squid.GetHttpPort(2) }, [], nil)
-      TEST(lambda { Squid.DelHttpPort(1) }, [], nil)
-      TEST(lambda { Squid.GetHttpPort(1) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(1) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(2) }, [], nil)
+      TEST(-> { Squid.DelHttpPort(1) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(1) }, [], nil)
 
       DUMP("")
       DUMP("DelHttpPort(100) - out of range")
-      TEST(lambda { Squid.DelHttpPort(100) }, [], nil)
-      TEST(lambda { Squid.GetHttpPort(100) }, [], nil)
-      TEST(lambda { Squid.GetHttpPort(0) }, [], nil)
+      TEST(-> { Squid.DelHttpPort(100) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(100) }, [], nil)
+      TEST(-> { Squid.GetHttpPort(0) }, [], nil)
 
       nil
     end

--- a/testsuite/tests/Squid.rb
+++ b/testsuite/tests/Squid.rb
@@ -6,7 +6,7 @@ module Yast
       # testedfiles: Squid.ycp
 
       Yast.include self, "testsuite.rb"
-      @READ = {
+      @read = {
         "squid" => {
           "http_port"                 => [
             ["localhost:3128"],
@@ -69,10 +69,10 @@ module Yast
           "no_cache"                  => [["deny", "QUERY"]]
         }
       }
-      @READ = { "etc" => @READ }
+      @read = { "etc" => @read }
 
-      @WRITE = {}
-      @EXECUTE = {
+      @write = {}
+      @execute = {
         "target" => {
           "bash_output" => {
             "exit"   => 0,
@@ -83,7 +83,7 @@ module Yast
       }
 
       Yast.import "Squid"
-      TESTSUITE_INIT([@READ, @WRITE, @EXECUTE], nil)
+      TESTSUITE_INIT([@read, @write, @execute], nil)
 
       Squid.Read
 
@@ -150,9 +150,9 @@ module Yast
 
       DUMP("")
       DUMP("ACLIsUsedBy(0) - QUERY")
-      TEST(-> { Squid.ACLIsUsedBy(0) }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.ACLIsUsedBy(0) }, [@read, @write, @execute], nil)
       DUMP("ACLIsUsedBy(1)")
-      TEST(-> { Squid.ACLIsUsedBy(1) }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { Squid.ACLIsUsedBy(1) }, [@read, @write, @execute], nil)
 
       DUMP("==================================================")
       DUMP("================  HTTP_ACCESS  ===================")

--- a/testsuite/tests/SquidACL.rb
+++ b/testsuite/tests/SquidACL.rb
@@ -4,7 +4,7 @@ module Yast
   class SquidACLClient < Client
     def main
       # testedfiles: SquidACL.ycp
-      @READ = {
+      @read = {
         "squid" => {
           "acl"         => [
             "QUERY urlpath_regex cgi-bin \\?",
@@ -39,8 +39,8 @@ module Yast
         }
       }
 
-      @WRITE = {}
-      @EXECUTE = {}
+      @write = {}
+      @execute = {}
 
       Yast.include self, "testsuite.rb"
       # TESTSUITE_INIT([READ,WRITE,EXECUTE], nil);

--- a/testsuite/tests/SquidACL.rb
+++ b/testsuite/tests/SquidACL.rb
@@ -43,14 +43,14 @@ module Yast
       @EXECUTE = {}
 
       Yast.include self, "testsuite.rb"
-      #TESTSUITE_INIT([READ,WRITE,EXECUTE], nil);
+      # TESTSUITE_INIT([READ,WRITE,EXECUTE], nil);
 
       Yast.import "SquidACL"
 
       DUMP("SupportedACLs()")
-      TEST(lambda { SquidACL.SupportedACLs }, [], nil)
+      TEST(-> { SquidACL.SupportedACLs }, [], nil)
       DUMP("GetTypesToComboBox()")
-      TEST(lambda { SquidACL.GetTypesToComboBox }, [], nil)
+      TEST(-> { SquidACL.GetTypesToComboBox }, [], nil)
 
       nil
     end

--- a/testsuite/tests/SquidErrorMessages.rb
+++ b/testsuite/tests/SquidErrorMessages.rb
@@ -5,7 +5,7 @@ module Yast
     def main
       # testedfiles: SquidErrorMessages.ycp
 
-      @READ = [
+      @read = [
         {
           "target" => {
             "dir" => [
@@ -26,8 +26,8 @@ module Yast
         { "target" => { "stat" => { "isdir" => false } } }
       ]
 
-      @WRITE = {}
-      @EXECUTE = {}
+      @write = {}
+      @execute = {}
 
       Yast.include self, "testsuite.rb"
 
@@ -35,28 +35,28 @@ module Yast
       Yast.import "FileUtils"
 
       DUMP("GetLanguages()")
-      TEST(-> { SquidErrorMessages.GetLanguages }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { SquidErrorMessages.GetLanguages }, [@read, @write, @execute], nil)
 
       DUMP("")
       DUMP("GetLanguagesToComboBox()")
       TEST(-> { SquidErrorMessages.GetLanguagesToComboBox }, [
-             @READ,
-             @WRITE,
-             @EXECUTE
+             @read,
+             @write,
+             @execute
            ], nil)
 
       DUMP("")
       DUMP("GetPath(\"en\")")
       TEST(-> { SquidErrorMessages.GetPath("en") }, [
-             @READ,
-             @WRITE,
-             @EXECUTE
+             @read,
+             @write,
+             @execute
            ], nil)
       DUMP("GetPath(\"uk\")")
       TEST(-> { SquidErrorMessages.GetPath("uk") }, [
-             @READ,
-             @WRITE,
-             @EXECUTE
+             @read,
+             @write,
+             @execute
            ], nil)
 
       DUMP("")
@@ -74,9 +74,9 @@ module Yast
           Ops.add(SquidErrorMessages.err_msg_dir, "/en")
         )
       end, [
-        @READ,
-        @WRITE,
-        @EXECUTE
+        @read,
+        @write,
+        @execute
       ], nil)
       DUMP(
         Ops.add(
@@ -92,9 +92,9 @@ module Yast
           Ops.add(SquidErrorMessages.err_msg_dir, "/ru")
         )
       end, [
-        @READ,
-        @WRITE,
-        @EXECUTE
+        @read,
+        @write,
+        @execute
       ], nil)
 
       nil

--- a/testsuite/tests/SquidErrorMessages.rb
+++ b/testsuite/tests/SquidErrorMessages.rb
@@ -34,31 +34,30 @@ module Yast
       Yast.import "SquidErrorMessages"
       Yast.import "FileUtils"
 
-
       DUMP("GetLanguages()")
-      TEST(lambda { SquidErrorMessages.GetLanguages }, [@READ, @WRITE, @EXECUTE], nil)
+      TEST(-> { SquidErrorMessages.GetLanguages }, [@READ, @WRITE, @EXECUTE], nil)
 
       DUMP("")
       DUMP("GetLanguagesToComboBox()")
-      TEST(lambda { SquidErrorMessages.GetLanguagesToComboBox }, [
-        @READ,
-        @WRITE,
-        @EXECUTE
-      ], nil)
+      TEST(-> { SquidErrorMessages.GetLanguagesToComboBox }, [
+             @READ,
+             @WRITE,
+             @EXECUTE
+           ], nil)
 
       DUMP("")
       DUMP("GetPath(\"en\")")
-      TEST(lambda { SquidErrorMessages.GetPath("en") }, [
-        @READ,
-        @WRITE,
-        @EXECUTE
-      ], nil)
+      TEST(-> { SquidErrorMessages.GetPath("en") }, [
+             @READ,
+             @WRITE,
+             @EXECUTE
+           ], nil)
       DUMP("GetPath(\"uk\")")
-      TEST(lambda { SquidErrorMessages.GetPath("uk") }, [
-        @READ,
-        @WRITE,
-        @EXECUTE
-      ], nil)
+      TEST(-> { SquidErrorMessages.GetPath("uk") }, [
+             @READ,
+             @WRITE,
+             @EXECUTE
+           ], nil)
 
       DUMP("")
       DUMP(

--- a/testsuite/tests/complex_include_test.rb
+++ b/testsuite/tests/complex_include_test.rb
@@ -16,9 +16,10 @@ describe "Yast::SquidComplexInclude" do
       initialize_squid_complex(self)
     end
 
-    private
+  private
 
     def load_widgets; end
+
     def load_screens; end
   end
 
@@ -33,7 +34,7 @@ describe "Yast::SquidComplexInclude" do
       allow(Yast::Wizard).to receive(:RestoreHelp)
       allow(Yast::Squid).to receive(:AbortFunction)
       allow(Yast::Confirm).to receive(:MustBeRoot).and_return(root_privileges)
-      allow(Yast::PackageSystem).to receive(:CheckAndInstallPackages).with(['squid']).and_return(squid_installed)
+      allow(Yast::PackageSystem).to receive(:CheckAndInstallPackages).with(["squid"]).and_return(squid_installed)
       allow(Yast::Squid).to receive(:Read).and_return(squid_read)
     end
 

--- a/testsuite/tests/complex_include_test.rb
+++ b/testsuite/tests/complex_include_test.rb
@@ -1,0 +1,84 @@
+#! /usr/bin/env rspec
+
+require_relative "./test_helper"
+require_relative "../../src/include/squid/complex"
+
+Yast.import "Confirm"
+Yast.import "Squid"
+Yast.import "Wizard"
+Yast.import "PackageSystem"
+
+describe "Yast::SquidComplexInclude" do
+  class TestSquidClient < Yast::Client
+    include Yast::SquidComplexInclude
+
+    def initialize
+      initialize_squid_complex(self)
+    end
+
+    private
+
+    def load_widgets; end
+    def load_screens; end
+  end
+
+  describe "#ReadDialog" do
+    subject(:squid_client) { TestSquidClient.new }
+
+    let(:root_privileges) { true }
+    let(:squid_installed) { true }
+    let(:squid_read) { true }
+
+    before do
+      allow(Yast::Wizard).to receive(:RestoreHelp)
+      allow(Yast::Squid).to receive(:AbortFunction)
+      allow(Yast::Confirm).to receive(:MustBeRoot).and_return(root_privileges)
+      allow(Yast::PackageSystem).to receive(:CheckAndInstallPackages).with(['squid']).and_return(squid_installed)
+      allow(Yast::Squid).to receive(:Read).and_return(squid_read)
+    end
+
+    context "when executed without root privileges" do
+      let(:root_privileges) { false }
+
+      it "returns :abort" do
+        expect(squid_client.ReadDialog).to be(:abort)
+      end
+    end
+
+    context "when squid system is not installed" do
+      let(:squid_installed) { false }
+
+      it "returns :abort" do
+        expect(squid_client.ReadDialog).to be(:abort)
+      end
+    end
+
+    context "when Squid cannot be read" do
+      let(:squid_read) { false }
+
+      it "returns :abort" do
+        expect(squid_client.ReadDialog).to be(:abort)
+      end
+    end
+
+    context "when all requirements are accomplished" do
+      let(:service) { instance_double(Yast2::Systemd::Service) }
+      let(:service_widget) { instance_double(CWM::ServiceWidget, cwm_definition: {}) }
+
+      before do
+        allow(Yast::Squid).to receive(:service).and_return(service)
+        allow(::CWM::ServiceWidget).to receive(:new).and_return(service_widget)
+      end
+
+      it "load the service widget" do
+        expect(::CWM::ServiceWidget).to receive(:new).with(service)
+
+        squid_client.ReadDialog
+      end
+
+      it "returns :next" do
+        expect(squid_client.ReadDialog).to be(:next)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Avoiding crash when package is not present/installed yet.

> This module must have "squid" package installed in the system to work
properly. To ensure that requirement, it is being a "check and install"
through `PackageSystem` but  also has been necessary to postpone the
service widget initialization after checking the environment.

> Another significant change is that the "squid" installation isn't
optional anymore, aborting the execution of module if it is canceled.

> Additionally, the `initialize_squid_complex` method has been
"refactored" to improve the execution of the added test, moving the
widgets and screens initializations to their own private methods.

---

Related to https://bugzilla.suse.com/show_bug.cgi?id=1110076