### PR TITLE
Fix testsuite

### DIFF
--- a/package/yast2-squid.changes
+++ b/package/yast2-squid.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 20 11:19:29 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed failing old testsuite: do not depend on the environment,
+  skip log firewall absence in Mode.test() (bsc#1138668)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:40:14 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-squid.spec
+++ b/package/yast2-squid.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-squid
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Summary:        Configuration of squid
 License:        GPL-2.0-only

--- a/src/modules/Squid.rb
+++ b/src/modules/Squid.rb
@@ -1099,7 +1099,7 @@ module Yast
       Progress.NextStage
 
       Progress.set(false)
-      if !firewalld.read
+      if !firewalld.read && !Mode.test
         # bnc#808722: yast2 squid fail if SuSEfirewall in not installed
         # other or no firewall can be installed
         Builtins.y2warning("Cannot read firewall settings.")


### PR DESCRIPTION
## Problem
- Failing old testsuite

```bash
[   79s]  Read	.etc.squid."memory_replacement_policy" nil
[   79s]  Read	.etc.squid."minimum_object_size" [["0", "KB"]]
[   79s] +Log	Cannot read firewall settings.
[   79s]  Return	true
[   79s]  Dump	Squid::settings["cache_mem"]:["1"] == Squid::parameters["cache_mem"]:["2"]
[   79s]  Return	true
```

- It depends on firewall rpm installed for reading and logs the failure in case of absence.

## Fix

This fix is basically same approach than yast/yast-users#209

- Do not depend on firewall installed at all in Mode.test()
- 4.2.1