### PR TITLE
packaging: remove SuSEfirewall2 artifacts

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -1,7 +1,0 @@
-# Makefile.am for squid/src
-
-pkgdatadir = /etc/sysconfig/SuSEfirewall2.d/services
-pkgdata_DATA = SuSEfirewall2/squid
-
-EXTRA_DIST = $(pkgdata_DATA)
-

--- a/config/SuSEfirewall2/squid
+++ b/config/SuSEfirewall2/squid
@@ -1,7 +1,0 @@
-## Name: Squid Service
-## Description: Opens ports for Squid
-TCP=""
-UDP=""
-RPC=""
-IP=""
-BROADCAST=""

--- a/package/yast2-squid.spec
+++ b/package/yast2-squid.spec
@@ -60,7 +60,6 @@ rm -rf %{buildroot}/%{yast_plugindir}/libpy2ag_squid.la
 %yast_metainfo
 
 %files
-%config /etc/sysconfig/SuSEfirewall2.d/services/squid
 %{yast_yncludedir}
 %{yast_clientdir}
 %{yast_moduledir}


### PR DESCRIPTION
The default SUSE firewall is now firewalld and yast-squid code has also
already been adjusted for it. SuSEfirewall2 is about to be removed from
Tumbleweed.